### PR TITLE
fix: update canvas width when toggle tabs visibility

### DIFF
--- a/packages/gi-assets-basic/src/components/SideTabs/SideContainer.tsx
+++ b/packages/gi-assets-basic/src/components/SideTabs/SideContainer.tsx
@@ -15,6 +15,26 @@ const SideContainer: React.FC<SideContainerProps> = props => {
   const { children, width, visible, GISDK_ID, outSideFromCanvas, placement, height } = props;
   const { graph } = useContext();
   const divRef = React.useRef<HTMLDivElement>(null);
+    React.useEffect(() => {
+    if (!outSideFromCanvas) return;
+    const canvasContainer = document.getElementById(''.concat(GISDK_ID, '-graphin-container')) as HTMLElement;
+    if (!canvasContainer) return;
+    function ontransitionend(event) {
+      if (!['right', 'left', 'top', 'bottom'].includes(event.propertyName)) {
+        return;
+      }
+      var canvas = graph.get('canvas');
+      if (canvas) {
+        graph.changeSize(canvasContainer.offsetWidth, canvasContainer.offsetHeight);
+        graph.autoPaint();
+      }
+    }
+    canvasContainer.addEventListener('transitionend', ontransitionend);
+    return () => {
+      canvasContainer.removeEventListener('transitionend', ontransitionend);
+    }
+  }, [outSideFromCanvas]);
+
   React.useEffect(() => {
     const container = document.getElementById(`${GISDK_ID}-container`) as HTMLDivElement;
     const canvasContainer = document.getElementById(`${GISDK_ID}-graphin-container`) as HTMLDivElement;
@@ -107,11 +127,6 @@ const SideContainer: React.FC<SideContainerProps> = props => {
           }
         }
 
-        const canvas = graph.get('canvas');
-        if (canvas) {
-          graph.changeSize(canvasContainer.offsetWidth, canvasContainer.offsetHeight);
-          graph.autoPaint();
-        }
       } else {
         container.className = '';
         tabsContainer.className = '';
@@ -122,6 +137,14 @@ const SideContainer: React.FC<SideContainerProps> = props => {
         canvasContainer.style.transition = 'all 0.3s ease';
         tabsContainer.style.transition = 'all 0.3s ease';
       }
+    }
+  }, [graph, visible, outSideFromCanvas, placement]);
+
+  React.useEffect(() => {
+    const tabsContainer = divRef.current;
+    const canvasContainer = document.getElementById(`${GISDK_ID}-graphin-container`) as HTMLElement;
+    if (!tabsContainer) {
+      return;
     }
     return () => {
       tabsContainer.style.width = 'unset';
@@ -135,7 +158,7 @@ const SideContainer: React.FC<SideContainerProps> = props => {
       tabsContainer.style.right = 'unset';
       tabsContainer.style.left = 'unset';
     };
-  }, [graph, visible, outSideFromCanvas, placement]);
+  }, [placement]);
 
   return (
     <div className="gi-side-tabs-container" ref={divRef}>


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
1.  展开、折叠side tabs时，canvas的宽高没有对应的更新，导致点边的显示位置有偏差。见对比截图
2. 折叠side tabs时side tabs的transition动画没有生效

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![Untitled8](https://user-images.githubusercontent.com/3103676/210323114-3e6ad2d4-c08d-44ea-9fdb-5b6c5477bef2.gif)|  ![Untitled9](https://user-images.githubusercontent.com/3103676/210323175-ce811c48-b059-48d4-8025-a58436daaedc.gif)  |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
