### PR TITLE
feat: 元素高亮资产支持配置多选和上下游度数

### DIFF
--- a/packages/gi-assets-basic/src/components/ActivateRelations/ActivateRelations.tsx
+++ b/packages/gi-assets-basic/src/components/ActivateRelations/ActivateRelations.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import useBehaviorHook from '@antv/graphin/es/behaviors/useBehaviorHook';
+import { registerBehavior } from '@antv/g6';
+import ActivateRelationsBehavior from './activate-relations-v2';
+
+const defaultConfig = {
+  /**
+   * @description 是否禁用该功能
+   * @default false
+   */
+  disabled: false,
+  /**
+   * @description 可以是 mousenter，表示鼠标移入时触发；也可以是 click，鼠标点击时触发
+   * @default mouseenter
+   */
+  trigger: 'mouseenter',
+  /**
+   * @description 活跃节点状态。当行为被触发，需要被突出显示的节点和边都会附带此状态，默认值为  active；可以与 graph 实例的  nodeStyle  和  edgeStyle  结合实现丰富的视觉效果。
+   * @default active
+   */
+  activeState: 'active',
+  /**
+   * @description 非活跃节点状态。不需要被突出显示的节点和边都会附带此状态。默认值为  inactive。可以与 graph 实例的  nodeStyle  和  edgeStyle  结合实现丰富的视觉效果；
+   * @default inactive
+   */
+  inactiveState: 'inactive',
+  /**
+   * @description 高亮相连节点时是否重置已经选中的节点，默认为 false，即选中的节点状态不会被 activate-relations 覆盖；
+   * @default false
+   */
+  resetSelected: false,
+  // 上游扩展的度数 
+  upstreamDegree: 1,
+  // 下游扩展的度数 
+  downstreamDegree: 1,
+  // 多选组合键
+  modifierKey: 'alt',
+  // 是否支持多选
+  multiSelectEnabled: false,
+};
+
+export type ActivateRelationsProps = Partial<typeof defaultConfig>;
+
+registerBehavior('activate-relations-v2', ActivateRelationsBehavior);
+
+const ActivateRelations: React.FunctionComponent<ActivateRelationsProps> = props => {
+  useBehaviorHook({
+    type: 'activate-relations-v2',
+    userProps: props,
+    defaultConfig,
+  });
+  return null;
+};
+
+export default ActivateRelations;

--- a/packages/gi-assets-basic/src/components/ActivateRelations/Component.tsx
+++ b/packages/gi-assets-basic/src/components/ActivateRelations/Component.tsx
@@ -2,8 +2,9 @@ import { useContext } from '@antv/gi-sdk';
 import { Behaviors } from '@antv/graphin';
 import React from 'react';
 import ActiveEdge from './ActiveEdge';
+import ActivateRelations from './ActivateRelations';
 
-const { ActivateRelations, Hoverable } = Behaviors;
+const { Hoverable } = Behaviors;
 
 export interface CanvasSettingProps {
   enableNodeHover: boolean;
@@ -12,24 +13,34 @@ export interface CanvasSettingProps {
   trigger: string;
   upstreamDegree: number;
   downstreamDegree: number;
+  multiSelectEnabled: boolean;
+  modifierKey: string;
 }
 
 const ActivateRelationsAsset: React.FunctionComponent<CanvasSettingProps> = props => {
   const {
     enable,
     trigger,
-    //@TODO: 将来加上上下游的度数
     upstreamDegree,
-    //@TODO: 将来加上上下游的度数
     downstreamDegree,
     enableEdgeHover,
     enableNodeHover,
+    multiSelectEnabled,
+    modifierKey,
   } = props;
   const { persistentHighlight } = useContext();
 
   return (
     <>
-      {enable && !persistentHighlight && <ActivateRelations trigger={trigger} />}
+      {enable && !persistentHighlight && (
+        <ActivateRelations
+          trigger={trigger}
+          upstreamDegree={upstreamDegree}
+          downstreamDegree={downstreamDegree}
+          multiSelectEnabled={multiSelectEnabled}
+          modifierKey={modifierKey}
+        />
+      )}
       {enableNodeHover && <Hoverable bindType="node" />}
       {enableEdgeHover && <Hoverable bindType="edge" />}
       {enable && !persistentHighlight && <ActiveEdge />}

--- a/packages/gi-assets-basic/src/components/ActivateRelations/activate-relations-v2.ts
+++ b/packages/gi-assets-basic/src/components/ActivateRelations/activate-relations-v2.ts
@@ -1,0 +1,322 @@
+// 基于G6的activate-relations做了以下升级改造
+// 1. 支持多选进行高亮
+// 2. 支持分别定义高亮时上下游进行扩展的度数
+
+import { Graph, Item, G6Event, IG6GraphEvent, INode, ICombo, IEdge } from '@antv/g6';
+import { throttle } from '@antv/util';
+
+export default {
+  getDefaultCfg(): object {
+    return {
+      // 可选 mouseenter || click
+      // 选择 click 会监听 touch，mouseenter 不会监听
+      trigger: 'mouseenter',
+      activeState: 'active',
+      inactiveState: 'inactive',
+      resetSelected: false,
+      multiSelectEnabled: true,
+      modifierKey: 'alt',
+      upstreamDegree: 1,
+      downstreamDegree: 1,
+      shouldUpdate() {
+        return true;
+      },
+    };
+  },
+  getEvents(): { [key in G6Event]?: string } {
+    if ((this as any).get('trigger') === 'mouseenter') {
+      return {
+        'node:mouseenter': 'setAllItemStates',
+        'combo:mouseenter': 'setAllItemStates',
+        'node:mouseleave': 'clearActiveState',
+        'combo:mouseleave': 'clearActiveState',
+        'canvas:click': 'clearActiveState',
+        keyup: 'onKeyUp',
+        keydown: 'onKeyDown',
+      };
+    }
+    return {
+      'node:click': 'setAllItemStates',
+      'combo:click': 'setAllItemStates',
+      'canvas:click': 'clearActiveState',
+      'node:touchstart': 'setOnTouchStart',
+      'combo:touchstart': 'setOnTouchStart',
+      'canvas:touchstart': 'clearOnTouchStart',
+      keyup: 'onKeyUp',
+      keydown: 'onKeyDown',
+    };
+  },
+  setOnTouchStart(e: IG6GraphEvent) {
+    const self = this;
+    try {
+      const touches = (e.originalEvent as TouchEvent).touches;
+      const event1 = touches[0];
+      const event2 = touches[1];
+
+      if (event1 && event2) {
+        return;
+      }
+
+      e.preventDefault();
+    } catch (e) {
+      console.warn('Touch original event not exist!');
+    }
+    self.setAllItemStates(e);
+  },
+  clearOnTouchStart(e: IG6GraphEvent) {
+    const self = this;
+    try {
+      const touches = (e.originalEvent as TouchEvent).touches;
+      const event1 = touches[0];
+      const event2 = touches[1];
+
+      if (event1 && event2) {
+        return;
+      }
+
+      e.preventDefault();
+    } catch (e) {
+      console.warn('Touch original event not exist!');
+    }
+    self.clearActiveState(e);
+  },
+  setAllItemStates(e: IG6GraphEvent) {
+    //@ts-ignore
+    clearTimeout(this.timer);
+    this.throttleSetAllItemStates(e, this);
+  },
+  clearActiveState(e: any) {
+    //@ts-ignore
+    if (this.multiSelectEnabled && this.isModifierKeydown) {
+      return;
+    }
+    // avoid clear state frequently, it costs a lot since all the items' states on the graph need to be cleared
+    //@ts-ignore
+    this.timer = setTimeout(() => {
+      this.throttleClearActiveState(e, this);
+    }, 50);
+  },
+  throttleSetAllItemStates: throttle(
+    (e, self) => {
+      const item: INode = e.item as INode;
+      const graph: Graph = self.graph;
+      if (!graph || graph.destroyed) return;
+      self.item = item;
+      if (!self.shouldUpdate(e.item, { event: e, action: 'activate' }, self)) {
+        return;
+      }
+      const activeState = self.activeState;
+      const inactiveState = self.inactiveState;
+      const nodes = graph.getNodes();
+      const combos = graph.getCombos();
+      const edges = graph.getEdges();
+      const vEdges = graph.get('vedges');
+      const nodeLength = nodes.length;
+      const comboLength = combos.length;
+      const edgeLength = edges.length;
+      const vEdgeLength = vEdges.length;
+      const inactiveItems = self.inactiveItems || {};
+      const activeItems = self.activeItems || {};
+      const upstreamDegree = self.upstreamDegree || 1;
+      const downstreamDegree = self.downstreamDegree || 1;
+
+      if (!(self.multiSelectEnabled && self.isModifierKeydown)) {
+        for (let i = 0; i < nodeLength; i++) {
+          const node = nodes[i];
+          const nodeId = node.getID();
+          const hasSelected = node.hasState('selected');
+          if (self.resetSelected) {
+            if (hasSelected) {
+              graph.setItemState(node, 'selected', false);
+            }
+          }
+          if (activeItems[nodeId]) {
+            graph.setItemState(node, activeState, false);
+            delete activeItems[nodeId];
+          }
+          if (inactiveState && !inactiveItems[nodeId]) {
+            graph.setItemState(node, inactiveState, true);
+            inactiveItems[nodeId] = node;
+          }
+        }
+        for (let i = 0; i < comboLength; i++) {
+          const combo = combos[i];
+          const comboId = combo.getID();
+          const hasSelected = combo.hasState('selected');
+          if (self.resetSelected) {
+            if (hasSelected) {
+              graph.setItemState(combo, 'selected', false);
+            }
+          }
+          if (activeItems[comboId]) {
+            graph.setItemState(combo, activeState, false);
+            delete activeItems[comboId];
+          }
+          if (inactiveState && !inactiveItems[comboId]) {
+            graph.setItemState(combo, inactiveState, true);
+            inactiveItems[comboId] = combo;
+          }
+        }
+
+        for (let i = 0; i < edgeLength; i++) {
+          const edge = edges[i];
+          const edgeId = edge.getID();
+          if (activeItems[edgeId]) {
+            graph.setItemState(edge, activeState, false);
+            delete activeItems[edgeId];
+          }
+          if (inactiveState && !inactiveItems[edgeId]) {
+            graph.setItemState(edge, inactiveState, true);
+            inactiveItems[edgeId] = edge;
+          }
+        }
+
+        for (let i = 0; i < vEdgeLength; i++) {
+          const vEdge = vEdges[i];
+          const vEdgeId = vEdge.getID();
+          if (activeItems[vEdgeId]) {
+            graph.setItemState(vEdge, activeState, false);
+            delete activeItems[vEdgeId];
+          }
+          if (inactiveState && !inactiveItems[vEdgeId]) {
+            graph.setItemState(vEdge, inactiveState, true);
+            inactiveItems[vEdgeId] = vEdge;
+          }
+        }
+      }
+      enum DirectionEnum {
+        IN = 'in',
+        OUT = 'out',
+      }
+      const queue: Array<{
+        item: INode;
+        direction: DirectionEnum;
+        degree: number;
+      }> = [
+        {
+          item,
+          direction: DirectionEnum.IN,
+          degree: 0,
+        },
+        {
+          item,
+          direction: DirectionEnum.OUT,
+          degree: 0,
+        },
+      ];
+      // 按照upstreamDegree、downstreamDegree对应的上下游度数进行扩展，
+      // 高亮扩展出来的点和边
+      while (queue.length > 0) {
+        let { item, direction, degree } = queue.shift()!;
+
+        if (item && !item.destroyed) {
+          if (inactiveState && inactiveItems[item.getID()]) {
+            graph.setItemState(item as Item, inactiveState, false);
+            delete inactiveItems[item.getID()];
+          }
+          if (!activeItems[item.getID()]) {
+            graph.setItemState(item as Item, activeState, true);
+            activeItems[item.getID()] = item;
+          }
+
+          if (
+            (direction === DirectionEnum.IN && degree < upstreamDegree) ||
+            (direction === DirectionEnum.OUT && degree < downstreamDegree)
+          ) {
+            const edges = direction === DirectionEnum.IN ? item.getInEdges() : item.getOutEdges();
+
+            edges.forEach(edge => {
+              const edgeId = edge.getID();
+              if (inactiveItems[edgeId]) {
+                graph.setItemState(edge as Item, inactiveState, false);
+                delete inactiveItems[edgeId];
+              }
+              if (!activeItems[edgeId]) {
+                graph.setItemState(edge as Item, activeState, true);
+                activeItems[edgeId] = edge;
+              }
+              edge.toFront();
+            });
+
+            item.getNeighbors(direction === DirectionEnum.IN ? 'source' : 'target').forEach(node => {
+              queue.push({
+                item: node,
+                direction,
+                degree: degree + 1,
+              });
+            });
+          }
+        }
+      }
+
+      self.activeItems = activeItems;
+      self.inactiveItems = inactiveItems;
+      graph.emit('afteractivaterelations', { item: e.item, action: 'activate' });
+    },
+    50,
+    {
+      trailing: true,
+      leading: true,
+    },
+  ),
+  throttleClearActiveState: throttle(
+    (e, self) => {
+      const graph = self.get('graph');
+      if (!graph || graph.destroyed) return;
+      if (!self.shouldUpdate(e.item, { event: e, action: 'deactivate' }, self)) return;
+
+      const activeState = self.activeState;
+      const inactiveState = self.inactiveState;
+
+      const activeItems = self.activeItems || {};
+      const inactiveItems = self.inactiveItems || {};
+      //@ts-ignore
+      Object.values(activeItems)
+        //@ts-ignore
+        .filter((item: INode | IEdge | ICombo) => !item.destroyed)
+        .forEach(item => {
+          graph.clearItemStates(item, activeState);
+        });
+      //@ts-ignore
+      Object.values(inactiveItems)
+        //@ts-ignore
+        .filter((item: INode | IEdge | ICombo) => !item.destroyed)
+        .forEach(item => {
+          graph.clearItemStates(item, inactiveState);
+        });
+      self.activeItems = {};
+      self.inactiveItems = {};
+      graph.emit('afteractivaterelations', {
+        item: e.item || self.get('item'),
+        action: 'deactivate',
+      });
+    },
+    50,
+    {
+      trailing: true,
+      leading: true,
+    },
+  ),
+
+  onKeyDown(e: IG6GraphEvent) {
+    const self: any = this;
+    if (!self.multiSelectEnabled) {
+      return;
+    }
+
+    const code = e.key;
+    if (!code) {
+      return;
+    }
+    if (code.toLowerCase() === self.modifierKey.toLowerCase()) {
+      self.isModifierKeydown = true;
+    } else {
+      self.isModifierKeydown = false;
+    }
+  },
+
+  onKeyUp() {
+    const self: any = this;
+    self.isModifierKeydown = false;
+  },
+};

--- a/packages/gi-assets-basic/src/components/ActivateRelations/registerMeta.ts
+++ b/packages/gi-assets-basic/src/components/ActivateRelations/registerMeta.ts
@@ -61,6 +61,26 @@ const registerMeta = context => {
         disable: true,
       },
     },
+    multiSelectEnabled: {
+      title: '允许多选',
+      type: 'string',
+      'x-component': 'Switch',
+      'x-decorator': 'FormItem',
+      default: false,
+      'x-component-props': {
+        disable: true,
+      },
+    },
+    modifierKey: {
+      title: '多选组合键, 按下键盘输入组合键，支持Alt, Control, Shift, Meta',
+      type: 'string',
+      'x-component': 'ModifierPicker',
+      'x-decorator': 'FormItem',
+      default: 'alt',
+      'x-component-props': {
+        disable: true,
+      },
+    },
   };
 };
 

--- a/packages/gi-common-components/src/SchemaField/ModifierPicker.tsx
+++ b/packages/gi-common-components/src/SchemaField/ModifierPicker.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Input } from 'antd';
+
+// 修饰键
+const modifierKey = {
+  alt: (event: KeyboardEvent) => event.altKey,
+  ctrl: (event: KeyboardEvent) => event.ctrlKey,
+  shift: (event: KeyboardEvent) => event.shiftKey,
+  meta: (event: KeyboardEvent) => {
+    return event.metaKey;
+  },
+};
+
+interface Props {
+  value: string;
+  onChange: (key: string) => void;
+}
+
+const ModifierPicker: React.FC<Props> = ({ value, onChange }) => {
+  const [key, setKey] = React.useState(value || 'alt');
+  return (
+    <Input
+      value={key}
+      //@ts-ignore
+      onKeyDown={(e: KeyboardEvent) => {
+        Object.keys(modifierKey).some(key => {
+          console.log({
+            key,
+            value: modifierKey[key](e),
+          });
+          if (modifierKey[key](e)) {
+            setKey(key);
+            onChange(key);
+            return true;
+          }
+        });
+      }}
+    />
+  );
+};
+
+export default ModifierPicker;

--- a/packages/gi-common-components/src/SchemaField/index.tsx
+++ b/packages/gi-common-components/src/SchemaField/index.tsx
@@ -7,6 +7,7 @@ import GroupSelect from '../CommonStyleSetting/GroupSelect';
 import { AssetCollapse, FormCollapse, Offset } from '../FormilyForm';
 import IconPicker from '../CommonStyleSetting/IconPicker';
 import IconSelector from '../CommonStyleSetting/IconSelector';
+import ModifierPicker from './ModifierPicker';
 
 const SchemaField: React.ReactNode = createSchemaField({
   components: {
@@ -26,6 +27,7 @@ const SchemaField: React.ReactNode = createSchemaField({
     GroupSelect,
     ArrayCollapse,
     ArrayItems,
+    ModifierPicker,
   },
 }) as any;
 export default SchemaField;


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [x] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [ ] Solve the issue and close #0

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
基于G6的activate-relations做了以下升级改造
1. 支持多选进行高亮
2. 支持分别定义高亮时上下游进行扩展的度数

### 🖼️ Screenshot
![image](https://user-images.githubusercontent.com/3103676/228144649-4fa773b2-d5d8-48e8-b74d-53be8b33f81b.png)


| Before | After |
| ------ | ----- |
| ❌     | ✅    |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
