### PR TITLE
fix: hugegraph 的 G6VP http 地址暂时需要配置

### DIFF
--- a/packages/gi-assets-hugegraph/src/components/Connect.tsx
+++ b/packages/gi-assets-hugegraph/src/components/Connect.tsx
@@ -78,6 +78,13 @@ const ConnectHugeGraph: React.FC<ConnectProps> = ({ updateToken, token }) => {
             message="正在连接 HugeGraph 数据库，请耐心等待……"
           />
         )}
+        <Form.Item
+          label="G6VP 服务"
+          name="httpServerURL"
+          rules={[{ required: true, message: 'G6VP HTTP 服务地址必填!' }]}
+        >
+          <Input placeholder="请输入 G6VP HTTP 服务地址" />
+        </Form.Item>
         <Form.Item label="URI" name="uri" rules={[{ required: true, message: '部署 HugeGraph 的服务器地址必填!' }]}>
           <Input placeholder="请输入 HugeGraph URI 服务地址" />
         </Form.Item>


### PR DESCRIPTION
fix: hugegraph 的 G6VP http 地址暂时需要配置

![image](https://user-images.githubusercontent.com/29593318/230570025-afc6bda3-bc24-4d35-9c6d-0242bb803fcc.png)
