### PR TITLE
feat: add ai assistant based by chatGPT

### DIFF
--- a/packages/gi-assets-advance/package.json
+++ b/packages/gi-assets-advance/package.json
@@ -33,6 +33,7 @@
     "@antv/gi-sdk": "workspace:*",
     "@antv/graphin-icons": "^1.0.0",
     "@antv/util": "^3.2.5",
+    "@uiw/react-markdown-preview": "^4.1.13",
     "ace-gremlin-editor": "^0.0.14",
     "codemirror": "^5.25.0",
     "copy-to-clipboard": "^3.3.2",
@@ -48,6 +49,8 @@
     "react-force-graph-3d": "^1.21.10",
     "react-json-view": "^1.21.3",
     "react-spring": "9.3.2",
+    "react-transition-group": "^4.4.5",
+    "react-draggable": "^4.4.5",
     "three": "^0.135.0",
     "use-immer": "^0.6.0"
   },

--- a/packages/gi-assets-advance/src/components/Assistant/Component.tsx
+++ b/packages/gi-assets-advance/src/components/Assistant/Component.tsx
@@ -1,0 +1,243 @@
+import { useContext, utils } from '@antv/gi-sdk';
+import { message as amessage } from 'antd';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
+import DG from 'react-draggable';
+import { CSSTransition } from 'react-transition-group';
+import { useController } from './hooks/useController';
+import { query } from '../../services/OpenAIQuery';
+import { extractCodeBlocks } from './utils/extractCodeBlocks';
+import { Message } from './utils/message';
+import { getWelcomeMessage } from './utils/prompt';
+import { Dialog } from './Dialog';
+import { Header } from './Header';
+import { ComponentContext } from './context';
+import { SUPPORT_LANGUAGES } from './constants';
+import type { CodeBlock } from './utils/extractCodeBlocks';
+import './index.less';
+
+/**
+ * react-draggable 在 React 18 存在一点类型问题
+ * 不这样的话会报错，并导致构建失败
+ */
+const Draggable: any = DG;
+
+const { getPositionStyles } = utils;
+
+type AssistantProps = {
+  apiKey: string;
+  draggable: boolean;
+  logo: string;
+  offset: [number, number];
+  placement: string;
+  prompt: string;
+  serviceId: string;
+  size: [number, number];
+  welcome: string;
+};
+
+const Assistant: React.FC<AssistantProps> = ({
+  apiKey,
+  draggable,
+  logo,
+  offset,
+  placement,
+  prompt,
+  serviceId,
+  size,
+  welcome,
+}) => {
+  const { services, schemaData, transform, updateContext, largeGraphLimit } = useContext();
+  const service = utils.getService(services, serviceId);
+  const controller = useController();
+  const assistantRef = useRef<HTMLDivElement>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const positionStyles = getPositionStyles(placement, offset);
+
+  const placementStyle = useMemo(() => {
+    switch (placement) {
+      case 'LB':
+        return { left: 0, bottom: 0 };
+      case 'RT':
+        return { right: 0, top: 0 };
+      case 'RB':
+        return { right: 0, bottom: 0 };
+      case 'LT':
+      default:
+        return { left: 0, top: 0 };
+    }
+  }, [placement]);
+
+  /**
+   * 查询图数据
+   * @param value
+   * @returns
+   */
+  const queryGraph = async (codeBlock: CodeBlock) => {
+    if (!service) return false;
+    const resultData = await service({
+      value: codeBlock.code,
+      limit: 25,
+    });
+    updateContext(draft => {
+      const res = transform(resultData);
+
+      if (res.nodes.length === 0) {
+        amessage.info('没有查询到数据');
+      }
+
+      if (res.nodes.length > largeGraphLimit) {
+        draft.largeGraphMode = true;
+        draft.largeGraphData = res;
+        draft.source = res;
+        draft.data = {
+          nodes: [],
+          edges: [],
+        };
+        draft.isLoading = false;
+        return;
+      }
+
+      draft.data = res;
+      draft.source = res;
+      draft.isLoading = false;
+    });
+    return true;
+  };
+
+  const addMessage = (message: Message) => {
+    setMessages(prev => [...prev, message]);
+  };
+
+  /**
+   * 发送消息及查询图数据
+   * @param message
+   * @returns
+   */
+  const sendMessage = async (message: Message) => {
+    if (!apiKey) {
+      amessage.error('请先设置API Key');
+      return false;
+    }
+
+    const newMessages = [...messages, message];
+    addMessage(message);
+    const response = await query(
+      newMessages.filter(({ status }) => status !== 'cancel'),
+      apiKey,
+      controller.signal,
+    );
+
+    if (!response) return false;
+
+    addMessage(
+      new Message({
+        role: response.message.role,
+        content: response.message.content,
+        status: 'success',
+      }),
+    );
+
+    const codeBlocks = extractCodeBlocks(response.message.content).filter(({ language }) =>
+      SUPPORT_LANGUAGES.includes(language.toLowerCase()),
+    );
+
+    if (codeBlocks.length) {
+      amessage.success('开始查询图数据...');
+      // 目前只执行第一个被支持语句的代码块
+      return await queryGraph(codeBlocks[0]);
+    }
+
+    return true;
+  };
+
+  const clearMessages = () => {
+    // 保留 reserved 的消息
+    setMessages(messages.filter(message => message.reserved));
+  };
+
+  /**
+   * 更新最后一条消息的状态
+   * @param status
+   */
+  const updateLastMessageStatus = (status: Message['status']) => {
+    setMessages(prev => {
+      const lastMessage = prev.filter(message => !message.reserved)[prev.length - 1];
+      if (lastMessage) {
+        lastMessage.status = status;
+      }
+      return [...prev];
+    });
+  };
+
+  /**
+   * 取消查询
+   */
+  const abortQuery = () => {
+    controller.abort();
+    updateLastMessageStatus('cancel');
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    if (schemaData) {
+      setMessages(prev => [...prev.splice(2, prev.length), ...getWelcomeMessage(welcome, prompt, schemaData)]);
+    }
+  }, [schemaData, welcome, prompt]);
+
+  return (
+    <Draggable
+      disabled={!draggable}
+      onStart={() => {
+        setTimeout(() => {
+          setIsDragging(true);
+        }, 100);
+      }}
+      onStop={() => {
+        setTimeout(() => {
+          setIsDragging(false);
+        }, 100);
+      }}
+      bounds=".gi-analysis"
+    >
+      <div className="assistant" style={positionStyles}>
+        <CSSTransition in={!isDialogOpen} timeout={300} classNames="dialog-button" unmountOnExit>
+          <div onClick={() => !isDragging && setIsDialogOpen(true)} className="dialog-button">
+            <img src={logo} width={size[0]} height={size[1]} alt="logo" />
+          </div>
+        </CSSTransition>
+        <CSSTransition in={isDialogOpen} timeout={300} classNames="dialog" unmountOnExit>
+          <div className="dialog-wrapper" ref={assistantRef} style={placementStyle}>
+            <div className="dialog-container">
+              <ComponentContext.Provider
+                value={{
+                  loading,
+                  setLoading,
+                  messages,
+                  onSendMessage: sendMessage,
+                  onInput: content =>
+                    sendMessage(
+                      new Message({
+                        role: 'user',
+                        content,
+                      }),
+                    ),
+                  abortQuery,
+                  clearMessages,
+                }}
+              >
+                <Header title="AI 助理" onClose={() => setIsDialogOpen(false)} />
+                <Dialog />
+              </ComponentContext.Provider>
+            </div>
+          </div>
+        </CSSTransition>
+      </div>
+    </Draggable>
+  );
+};
+
+export default Assistant;

--- a/packages/gi-assets-advance/src/components/Assistant/Dialog/index.less
+++ b/packages/gi-assets-advance/src/components/Assistant/Dialog/index.less
@@ -1,0 +1,83 @@
+.dialog-content::-webkit-scrollbar {
+  display: none;
+}
+
+.dialog-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  overflow: scroll;
+  color: white;
+
+  .list::-webkit-scrollbar {
+    display: none;
+  }
+
+  .list {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 10px;
+    padding: 10px;
+    overflow: scroll;
+
+    .message {
+      max-width: 80%;
+
+      .message-content {
+        padding: 10px 16px;
+        font-size: 14px !important;
+        border-radius: 5px;
+      }
+
+      .message-content:not(.wmde-markdown) {
+        white-space: pre-line;
+      }
+    }
+
+    .user {
+      margin-left: auto;
+
+      .message-content {
+        background-color: var(--primary-color);
+      }
+
+      .wmde-markdown {
+        p,
+        pre {
+          margin: 0 !important;
+          color: white;
+        }
+      }
+    }
+
+    .assistant {
+      margin-right: auto;
+    }
+  }
+
+  .input-container {
+    display: flex;
+    align-items: center;
+    padding: 5px;
+
+    .ant-spin-nested-loading {
+      width: 100%;
+      transition: cubic-bezier(0.075, 0.82, 0.165, 1);
+    }
+
+    .stop-query {
+      position: absolute;
+      top: 0;
+      left: 50%;
+      transform: translate(-50%, 50px);
+    }
+
+    .new-dialog {
+      margin: 0 10px;
+      font-size: 20px;
+    }
+  }
+}

--- a/packages/gi-assets-advance/src/components/Assistant/Dialog/index.tsx
+++ b/packages/gi-assets-advance/src/components/Assistant/Dialog/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import './index.less';
+import { Input } from './input';
+import { MessageList } from './list';
+
+export const Dialog: React.FC = () => {
+  return (
+    <div className="dialog-content">
+      <MessageList />
+      <Input />
+    </div>
+  );
+};

--- a/packages/gi-assets-advance/src/components/Assistant/Dialog/input.tsx
+++ b/packages/gi-assets-advance/src/components/Assistant/Dialog/input.tsx
@@ -1,0 +1,46 @@
+import { LoadingOutlined, SyncOutlined } from '@ant-design/icons';
+import { Input as AntdInput, Spin, Tooltip } from 'antd';
+import React, { useContext, useState } from 'react';
+import { ComponentContext } from '../context';
+
+export const Input: React.FC<{
+  defaultValue?: string;
+}> = (props) => {
+  const { onInput, clearMessages } = useContext(ComponentContext);
+  const { loading, setLoading } = useContext(ComponentContext);
+  const { defaultValue = '' } = props;
+  const [value, setValue] = useState(defaultValue);
+
+  const antIcon = <LoadingOutlined style={{ fontSize: 24 }} spin />;
+
+  return (
+    <div className="input-container">
+      <Spin indicator={antIcon} spinning={loading}>
+        <AntdInput.TextArea
+          autoSize
+          placeholder="AI 助理为您服务"
+          value={value}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              const valueToSend = value.trim();
+              e.preventDefault();
+              if (!!valueToSend) {
+                if (!onInput) return;
+                setLoading?.(true);
+                onInput(valueToSend).then((res) => {
+                  if (res) setValue('');
+                  setLoading?.(false);
+                });
+              }
+            }
+          }}
+          style={{ maxHeight: '60vh' }}
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </Spin>
+      <Tooltip title="新对话" mouseEnterDelay={1}>
+        <SyncOutlined className="new-dialog" onClick={clearMessages} />
+      </Tooltip>
+    </div>
+  );
+};

--- a/packages/gi-assets-advance/src/components/Assistant/Dialog/list.tsx
+++ b/packages/gi-assets-advance/src/components/Assistant/Dialog/list.tsx
@@ -1,0 +1,32 @@
+import React, { useContext, useEffect } from 'react';
+import { ComponentContext } from '../context';
+import { Message } from './message';
+
+export const MessageList: React.FC = () => {
+  const { messages } = useContext(ComponentContext);
+  const scrollToBottom = () => {
+    const list = document.querySelector('.list');
+    if (list) {
+      list.scrollTo({
+        top: list.scrollHeight,
+        behavior: 'smooth',
+      });
+    }
+  };
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
+
+  return (
+    <div className="list">
+      {messages
+        .filter((message) => message.role !== 'system')
+        .map((message) => (
+          <div key={message.timestamp} className={`message ${message.role}`}>
+            <Message {...message} />
+          </div>
+        ))}
+    </div>
+  );
+};

--- a/packages/gi-assets-advance/src/components/Assistant/Dialog/message.tsx
+++ b/packages/gi-assets-advance/src/components/Assistant/Dialog/message.tsx
@@ -1,0 +1,43 @@
+import { useContext } from '@antv/gi-sdk';
+import MarkdownPreview from '@uiw/react-markdown-preview';
+import { Tooltip } from 'antd';
+import React from 'react';
+import { Message as CMessage } from '../utils/message';
+
+export const Message: React.FC<CMessage> = (props) => {
+  const { role, content, timestamp } = props;
+  const { theme } = useContext();
+  const disablePreview = role === 'user' && !content.includes('`');
+
+  const time = new Date(timestamp).toLocaleString();
+
+  /**
+   * markdown 预览工具对于 ``` 语法的支持不够好
+   * 为了避免出现预览不正确的情况，这里将 ``` 语法替换为 ```js
+   * @param str
+   */
+  const getLegalContent = (str: string) => {
+    // 存在 ```xx 语法，不做处理
+    if (str.match(/```[\S]+/g) !== null) return str;
+    // 存在 ``` 语法，替换为 ```js
+    return str.replace(/```[\s]*\n([\s\S]*?)```/g, '```js\n$1```');
+  };
+
+  return (
+    <Tooltip title={time} mouseEnterDelay={1}>
+      <div>
+        {disablePreview ? (
+          <div className="message-content">{content}</div>
+        ) : (
+          <MarkdownPreview
+            wrapperElement={{
+              'data-color-mode': theme.mode,
+            }}
+            className="message-content"
+            source={getLegalContent(content)}
+          />
+        )}
+      </div>
+    </Tooltip>
+  );
+};

--- a/packages/gi-assets-advance/src/components/Assistant/Dialog/message.tsx
+++ b/packages/gi-assets-advance/src/components/Assistant/Dialog/message.tsx
@@ -6,7 +6,6 @@ import { Message as CMessage } from '../utils/message';
 
 export const Message: React.FC<CMessage> = (props) => {
   const { role, content, timestamp } = props;
-  const { theme } = useContext();
   const disablePreview = role === 'user' && !content.includes('`');
 
   const time = new Date(timestamp).toLocaleString();
@@ -31,7 +30,10 @@ export const Message: React.FC<CMessage> = (props) => {
         ) : (
           <MarkdownPreview
             wrapperElement={{
-              'data-color-mode': theme.mode,
+              'data-color-mode':
+                document.documentElement.getAttribute('data-theme') === 'dark'
+                  ? 'dark'
+                  : 'light',
             }}
             className="message-content"
             source={getLegalContent(content)}

--- a/packages/gi-assets-advance/src/components/Assistant/Header/index.less
+++ b/packages/gi-assets-advance/src/components/Assistant/Header/index.less
@@ -1,0 +1,57 @@
+.dialog-header {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 10px;
+
+  .dialog-header-button-group {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    
+    .dialog-header-cancel {
+      position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 18px;
+      height: 18px;
+      background-color: var(--warning-color);
+      border-radius: 50%;
+      cursor: pointer;
+
+      .cancel-button {
+        width: 10px;
+        height: 10px;
+        background-color: white;
+      }
+    }
+    
+    .dialog-header-close {
+      .close-button {
+        position: relative;
+        width: 18px;
+        height: 18px;
+        background-color: var(--primary-color);
+        border-radius: 50%;
+        cursor: pointer;
+      }
+
+      .close-button-bar {
+        position: absolute;
+        top: 8px;
+        left: 2px;
+        width: 14px;
+        height: 2px;
+        background-color: #fff;
+      }
+
+      .close-button-bar:first-child {
+        transform: rotate(45deg);
+      }
+
+      .close-button-bar:last-child {
+        transform: rotate(-45deg);
+      }
+    }
+  }
+}

--- a/packages/gi-assets-advance/src/components/Assistant/Header/index.tsx
+++ b/packages/gi-assets-advance/src/components/Assistant/Header/index.tsx
@@ -1,0 +1,33 @@
+import React, { useContext } from 'react';
+import { Tooltip } from 'antd';
+import { ComponentContext } from '../context';
+import './index.less';
+
+type HeaderProps = {
+  title: string;
+  onClose: () => void;
+};
+
+export const Header: React.FC<HeaderProps> = ({ title, onClose }) => {
+  const { loading, abortQuery } = useContext(ComponentContext);
+  return (
+    <div className="dialog-header">
+      <div className="dialog-header-title">{title}</div>
+      <div className="dialog-header-button-group">
+        {loading && (
+          <Tooltip title="停止查询" mouseEnterDelay={1}>
+            <div className="dialog-header-cancel" onClick={abortQuery}>
+              <div className="cancel-button"></div>
+            </div>
+          </Tooltip>
+        )}
+        <div className="dialog-header-close" onClick={onClose}>
+          <div className="close-button">
+            <div className="close-button-bar"></div>
+            <div className="close-button-bar"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/gi-assets-advance/src/components/Assistant/constants.ts
+++ b/packages/gi-assets-advance/src/components/Assistant/constants.ts
@@ -1,0 +1,2 @@
+/** 支持解析的语言 */
+export const SUPPORT_LANGUAGES = ['cypher'];

--- a/packages/gi-assets-advance/src/components/Assistant/context.ts
+++ b/packages/gi-assets-advance/src/components/Assistant/context.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+import { Message } from './utils/message';
+
+export const ComponentContext = createContext<{
+  abortQuery?: () => void;
+  clearMessages?: () => void;
+  loading?: boolean;
+  messages: Message[];
+  onInput?: (value: string) => Promise<boolean>;
+  onSendMessage?: (message: Message) => Promise<boolean>;
+  setLoading?: React.Dispatch<React.SetStateAction<boolean>>;
+}>({
+  messages: [],
+});

--- a/packages/gi-assets-advance/src/components/Assistant/hooks/useController.ts
+++ b/packages/gi-assets-advance/src/components/Assistant/hooks/useController.ts
@@ -1,0 +1,11 @@
+import { useRef } from 'react';
+
+export const useController = () => {
+  const controller = useRef<AbortController>(new AbortController());
+
+  if (controller.current.signal.aborted) {
+    controller.current = new AbortController();
+  }
+
+  return controller.current;
+};

--- a/packages/gi-assets-advance/src/components/Assistant/index.less
+++ b/packages/gi-assets-advance/src/components/Assistant/index.less
@@ -1,0 +1,54 @@
+.assistant {
+  z-index: 999;
+  font-size: 14px;
+
+  .dialog-enter {
+    transform: scale(0.9);
+    opacity: 0;
+  }
+
+  .dialog-button {
+    img {
+      -webkit-user-drag: none;
+    }
+  }
+
+  .dialog-enter-active,
+  .dialog-button-enter-active {
+    transform: scale(1);
+    opacity: 1;
+    transition: opacity 300ms, transform 300ms;
+  }
+
+  .dialog-exit,
+  dialog-button-exit {
+    transform: scale(1);
+    opacity: 1;
+  }
+
+  .dialog-exit-active,
+  .dialog-button-exit-active {
+    transform: scale(0.9);
+    opacity: 0;
+    transition: opacity 300ms, transform 300ms;
+  }
+
+  .dialog-wrapper {
+    position: absolute;
+    width: 250px;
+    height: 400px;
+    background: white;
+    border-radius: 10px;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+
+    .dialog-container {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+      padding-top: 10px;
+      background: var(--layout-background);
+      border-radius: 10px;
+    }
+  }
+}

--- a/packages/gi-assets-advance/src/components/Assistant/index.ts
+++ b/packages/gi-assets-advance/src/components/Assistant/index.ts
@@ -1,0 +1,5 @@
+import Component from './Component';
+import info from './info';
+import registerMeta from './registerMeta';
+
+export default { info, component: Component, registerMeta };

--- a/packages/gi-assets-advance/src/components/Assistant/info.ts
+++ b/packages/gi-assets-advance/src/components/Assistant/info.ts
@@ -1,0 +1,13 @@
+const ASSET_ID = 'Assistant';
+
+const info = {
+  id: ASSET_ID,
+  name: 'AI 助理',
+  desc: 'AI 助理',
+  cover: 'http://xxx.jpg',
+  category: 'system-interaction',
+  services: ['CypherQuery', 'GremlinQuery'],
+  icon: 'icon-robot',
+  type: 'AUTO',
+};
+export default info;

--- a/packages/gi-assets-advance/src/components/Assistant/registerMeta.ts
+++ b/packages/gi-assets-advance/src/components/Assistant/registerMeta.ts
@@ -1,0 +1,137 @@
+import { utils } from '@antv/gi-sdk';
+import info from './info';
+
+const registerMeta = (context) => {
+  const { services, engineId } = context;
+  const { options, defaultValue } = utils.getServiceOptionsByEngineId(
+    services,
+    info.services[0],
+    engineId
+  );
+
+  const schema = {
+    apiKey: {
+      title: 'API KEY',
+      type: 'string',
+      'x-decorator': 'FormItem',
+      'x-component': 'Input.Password',
+      default: '',
+    },
+
+    serviceId: {
+      title: '数据服务',
+      type: 'string',
+      'x-decorator': 'FormItem',
+      'x-component': 'Select',
+      'x-component-props': {
+        options: options,
+      },
+      default: defaultValue,
+    },
+    logo: {
+      title: 'Logo',
+      type: 'string',
+      'x-decorator': 'FormItem',
+      'x-component': 'Input',
+      default:
+        'https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*n07bSaB--F4AAAAAAAAAAAAADmJ7AQ/original',
+    },
+    size: {
+      title: '尺寸',
+      type: 'string',
+      'x-decorator': 'FormItem',
+      'x-component': 'Offset',
+      'x-component-props': {
+        min: 10,
+        max: 100,
+      },
+      default: [50, 50],
+    },
+    placement: {
+      title: '位置',
+      type: 'string',
+      'x-decorator': 'FormItem',
+      'x-component': 'Select',
+      'x-component-props': {
+        options: [
+          {
+            value: 'LT',
+            label: '左上',
+          },
+          {
+            value: 'RT',
+            label: '右上',
+          },
+          {
+            value: 'LB',
+            label: '左下',
+          },
+          {
+            value: 'RB',
+            label: '右下',
+          },
+        ],
+      },
+      default: 'LT',
+    },
+    offset: {
+      title: '偏移量',
+      type: 'string',
+      'x-decorator': 'FormItem',
+      'x-component': 'Offset',
+      'x-component-props': {
+        min: 0,
+        max: 400,
+      },
+      default: [100, 20],
+    },
+    draggable: {
+      title: '可拖拽',
+      type: 'boolean',
+      'x-decorator': 'FormItem',
+      'x-component': 'Switch',
+      default: true,
+    },
+    welcome: {
+      title: '欢迎语',
+      type: 'string',
+      'x-decorator': 'FormItem',
+      'x-component': 'Input.TextArea',
+      'x-component-props': {
+        autoSize: true,
+      },
+      default:
+        '您好！我是 GraphInsight 助理。请问有什么关于 GraphInsight 的问题或需求？',
+    },
+    prompt: {
+      title: '提示词',
+      type: 'string',
+      'x-decorator': 'FormItem',
+      'x-component': 'Input.TextArea',
+      'x-component-props': {
+        placeholder: '支持的变量：graphSchema，使用方式："${graphSchema}"',
+        autoSize: true,
+      },
+      default:
+        'GraphInsight 是一个可扩展的图可视分析平台，包括数据源管理、构图、图元素个性化配置、图可视分析等功能模块。\n' +
+        '你的任务是作为助理机器人，为 GraphInsight 的用户提供使用指引，包括根据用户的需求生成对应的 Cypher 查询语句。\n' +
+        'Cypher 语句是应用于 Neo4j 声明式图查询语言\n' +
+        '例如，当用户说“我想找出回答数最多的问题”，你可以以下列方式给出查询：\n' +
+        '```Cypher\n' +
+        'MATCH(q:Question)<-[:ANSWERED]-(a:Answer)\n' +
+        'WITH q,count(a)AS answer_count\n' +
+        'ORDERBY answer_count DESC\n' +
+        'LIMIT1\n' +
+        'RETURN q, answer_count\n' +
+        '```\n' +
+        '当前用户查看的图的数据信息如下：\n' +
+        '${graphSchema}' +
+        '\n请不要回答与 GraphInsight 无关的问题。\n' +
+        '你只需要根据用户的回答给出查询代码，并告知用户正在为您查询，不需要做过多的解释。\n' +
+        '下面开始和用户的对话。',
+    },
+  };
+  return schema;
+};
+
+export default registerMeta;

--- a/packages/gi-assets-advance/src/components/Assistant/utils/extractCodeBlocks.ts
+++ b/packages/gi-assets-advance/src/components/Assistant/utils/extractCodeBlocks.ts
@@ -1,0 +1,22 @@
+export type CodeBlock = {
+  language: string;
+  code: string;
+};
+
+/**
+ * 提取 Markdown 中的代码块
+ * @param content
+ */
+export function extractCodeBlocks(markdown: string) {
+  const codeBlockRegex = /```([a-zA-Z]+)?(?:\n)([\s\S]*?)```/g;
+  const codeBlocks: CodeBlock[] = [];
+
+  let match;
+  while ((match = codeBlockRegex.exec(markdown)) !== null) {
+    const language = match[1] ? match[1] : 'unknown';
+    const code = match[2].replace(/\n/g, ' ').trim();
+    codeBlocks.push({ language, code });
+  }
+
+  return codeBlocks;
+}

--- a/packages/gi-assets-advance/src/components/Assistant/utils/message.ts
+++ b/packages/gi-assets-advance/src/components/Assistant/utils/message.ts
@@ -1,0 +1,27 @@
+interface Base {
+  status?: 'pending' | 'success' | 'cancel';
+  role?: 'system' | 'assistant' | 'user';
+  content?: string;
+  timestamp?: number;
+  reserved?: boolean;
+}
+
+export class Message implements Base {
+  status: 'pending' | 'success' | 'cancel';
+
+  role: 'system' | 'assistant' | 'user';
+
+  content: string;
+
+  timestamp: number;
+
+  reserved: boolean;
+
+  constructor(props: Partial<Base>) {
+    this.status = props.status || 'pending';
+    this.role = props.role || 'user';
+    this.content = props.content || '';
+    this.timestamp = props.timestamp || Date.now();
+    this.reserved = props.reserved || false;
+  }
+}

--- a/packages/gi-assets-advance/src/components/Assistant/utils/prompt.ts
+++ b/packages/gi-assets-advance/src/components/Assistant/utils/prompt.ts
@@ -1,0 +1,49 @@
+import type { GraphSchemaData } from '@antv/gi-sdk';
+import { Message } from './message';
+
+/**
+ * 转换图的数据信息为自然语言
+ */
+export function schemaToNL(schema: GraphSchemaData) {
+  const { nodes, edges } = schema;
+
+  const nodesDescription = `图中有 ${nodes.length} 种节点，分别是：${nodes
+    .map((node) => `"${node.nodeType}"`)
+    .join('，')}。`;
+  const edgesDescription = `图中有 ${edges.length} 中边，分别是 ${edges
+    .map((edge) => `"${edge.edgeType}"`)
+    .join('，')}。`;
+
+  return `${nodesDescription} ${edgesDescription}`;
+}
+
+export function getPrompt(prompt: string, schema: GraphSchemaData) {
+  const graphSchema = schemaToNL(schema);
+
+  return prompt.replace(/\$\{graphSchema\}/g, graphSchema);
+}
+
+export function getWelcomeMessage(
+  welcome: string,
+  prompt: string,
+  schema: GraphSchemaData
+) {
+  return [
+    prompt &&
+      new Message({
+        status: 'success',
+        role: 'system',
+        content: getPrompt(prompt, schema),
+        timestamp: Date.now(),
+        reserved: true,
+      }),
+    welcome &&
+      new Message({
+        status: 'success',
+        role: 'assistant',
+        content: welcome,
+        timestamp: Date.now(),
+        reserved: true,
+      }),
+  ].filter(Boolean) as Message[];
+}

--- a/packages/gi-assets-advance/src/components/index.tsx
+++ b/packages/gi-assets-advance/src/components/index.tsx
@@ -23,7 +23,9 @@ import TemplateQuery from './TemplateQuery';
 import ThemeSetting from './ThemeSetting';
 import Undo from './Undo';
 import JSONMode from './JSONMode';
+import Assistant from './Assistant';
 export {
+  Assistant,
   StyleSetting,
   SnapshotGallery,
   GremlinQuery,

--- a/packages/gi-assets-advance/src/services/OpenAIQuery.ts
+++ b/packages/gi-assets-advance/src/services/OpenAIQuery.ts
@@ -1,0 +1,41 @@
+import { Message } from '../components/Assistant/utils/message';
+
+export function query(
+  messages: Message[],
+  apiKey: string,
+  signal?: AbortSignal,
+): Promise<{
+  status: 'success' | 'cancel' | 'failed';
+  message: any;
+}> {
+  return fetch('https://api.openai.com/v1/chat/completions', {
+    signal,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: messages.map(({ role, content }) => ({ role, content })),
+    }),
+  })
+    .then(res => res.json())
+    .then(res => {
+      return {
+        status: 'success' as const,
+        message: res.choices[0].message,
+      };
+    })
+    .catch(error => {
+      if (error.name === 'AbortError')
+        return {
+          status: 'cancel',
+          message: null,
+        };
+      return {
+        status: 'failed',
+        message: error.message,
+      };
+    });
+}


### PR DESCRIPTION
**资产类别**：自运行组件
**配置项**：
* `API KEY`: [OpenAI API KEY](https://platform.openai.com/account/api-keys)
* `数据服务`
* `Logo`: 自定义图标 URL 地址
* `尺寸`: 图标尺寸
* `偏移量`: 图标偏移量
* `可拖拽`: 图标及对话窗口是否可拖拽
* `欢迎语`: 用户欢迎语，会作为第一句向用户发起的对话
* `提示词`: chatGPT 提示词

**使用方式**
1. 配置 `API KEY` (必填) 及其他配置项
2. 点击图标唤起对话窗口
<img width="694" alt="image" src="https://user-images.githubusercontent.com/25787943/234003509-db241bdd-9103-4aef-89f1-73d1566b9abd.png">

**演示视频**
- 本视频使用 Neo4J 作为数据源

https://user-images.githubusercontent.com/25787943/234010672-8d58a06e-4fe4-44c0-8007-12adc1b825c7.mov



