### PR TITLE
node Image Type bug

### DIFF
--- a/packages/gi-assets-basic/src/elements/SimpleNode/registerTransform.ts
+++ b/packages/gi-assets-basic/src/elements/SimpleNode/registerTransform.ts
@@ -41,6 +41,7 @@ const getIconStyleByConfig = (style, data) => {
       return {
         fill: 'transparent',
         size: [keyshape.size, keyshape.size],
+        type: 'image',
         clip: { r: keyshape.size / 2 },
         value: value,
       };


### PR DESCRIPTION
In order to add an image type icon to the nodes in the canvas, the relevant line must be added.