### PR TITLE
chore: update publish process

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "restricted",
+  "baseBranch": "master",
+  "updateInternalDependencies": "patch",
+  "ignore": ["my-custom-server", "@antv/gi-site", "@antv/gi-portal", "@antv/gi-assets-testing", "@antv/gi-mock-data"]
+}

--- a/README.md
+++ b/README.md
@@ -228,33 +228,49 @@ nvm alias default v16.17.0
 
 ## 如何发布版本
 
-因为我们组件间的依赖关系用 pnpm 管理的，即`workspace:*`，因此发布到 npm 仓库，可以使用`pnpm publish`，该命令会自动将`workspace:*`转化为对应的版本。
+G6VP 采用 [changesets](https://pnpm.io/using-changesets) 来进行包版本管理和发布，因此不需要手动维护版本号，只需要在提交代码时，使用`pnpm run changeset`来生成对应的版本号即可。
 
-- 1. 进入每个子包中，执行发布命令
+- 1. 发布前准备
 
+按照下列步骤选择要发布的子包并更新版本号
+
+```bash
+# 添加需要发布的子包
+pnpm changeset
+
+# 更新子包版本号，并生成 changeset 文件
+pnpm changeset version
 ```
-npm run npm:publish
+
+> 发布完成后再将生成的 changeset 文件添加变更并提交到主分支仓库
+
+- 2. 发布子包
+
+> 需要提前登录
+
+```bash
+pnpm publish -r
 ```
 
-- 2. 子包发布后，需要同步到 CDN 上
+- 3. 子包发布后，需要同步到 CDN 上
 
 如果是公开的，国内用：https://www.jsdelivr.com/ ，国外可用：https://unpkg.com/
 如果是非公开的，则使用给自公司的 CDN 平台进行同步
 
-- 3. 发布主站点
+- 4. 发布主站点
 
-```
+```bash
 cd pacakges/gi-site
 npm run build
 ```
 
-- 4. 本地验证
+- 5. 本地验证
 
 执行 `code dist` ,使用 vscode 打开站点的产物，使用 live-server 等工具，将站点产物托管起来。访问 web 地址，验证站点是否正常运行，主要需要验证的点是，各个子包的产物是否正确发布到 CDN 上
 
-- 5. 发布到 github pages 上
+- 6. 发布到 github pages 上
 
-```
+```bash
 cd packages/gi-site
 npm run deploy
 ```

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "umi": "3.x"
   },
   "devDependencies": {
+    "@changesets/cli": "^2.26.1",
     "@types/react": "17.x",
     "@types/react-dom": "17.x",
     "babel-loader": "^8.2.5",

--- a/packages/gi-assets-advance/package.json
+++ b/packages/gi-assets-advance/package.json
@@ -23,7 +23,9 @@
     "prettier": "prettier --write ./src/**/**/**/*.js",
     "start": "npm run clean && father build --watch",
     "test": "jest",
-    "npm:publish": "npm run build && node ../../scripts/publish_backup.js && npm publish && node ../../scripts/publish_recover.js"
+    "npm:publish": "npm publish",
+    "prepublishOnly": "npm run build && node ../../scripts/publish_backup.js",
+    "postpublish": "node ../../scripts/publish_recover.js"
   },
   "dependencies": {
     "@ant-design/icons": "^4.6.2",

--- a/packages/gi-assets-algorithm/package.json
+++ b/packages/gi-assets-algorithm/package.json
@@ -29,7 +29,9 @@
     "prettier": "prettier --write ./src/**/**/**/*.js",
     "start": "npm run clean && father build --watch",
     "test": "jest",
-    "npm:publish": "npm run build && node ../../scripts/publish_backup.js && npm publish  && node ../../scripts/publish_recover.js"
+    "npm:publish": "npm publish",
+    "prepublishOnly": "npm run build && node ../../scripts/publish_backup.js",
+    "postpublish": "node ../../scripts/publish_recover.js"
   },
   "dependencies": {
     "@antv/gi-sdk": "workspace:*",

--- a/packages/gi-assets-basic/package.json
+++ b/packages/gi-assets-basic/package.json
@@ -29,7 +29,9 @@
     "start": "npm run clean && father build --watch",
     "test": "jest",
     "build:umd:analysis": "webpack  --mode production  -c ../../webpack.config.js --env path=/packages/gi-assets-basic analysis=true",
-    "npm:publish": "npm run build && node ../../scripts/publish_backup.js && npm publish && node ../../scripts/publish_recover.js"
+    "npm:publish": "npm publish",
+    "prepublishOnly": "npm run build && node ../../scripts/publish_backup.js",
+    "postpublish": "node ../../scripts/publish_recover.js"
   },
   "dependencies": {
     "@ant-design/icons": "latest",

--- a/packages/gi-assets-galaxybase/package.json
+++ b/packages/gi-assets-galaxybase/package.json
@@ -22,7 +22,9 @@
     "remove:antd": "rm -rf ./node_modules/antd",
     "start": "npm run clean && father build --watch",
     "test": "jest",
-    "npm:publish": "npm run build && node ../../scripts/publish_backup.js && npm publish && node ../../scripts/publish_recover.js"
+    "npm:publish": "npm publish",
+    "prepublishOnly": "npm run build && node ../../scripts/publish_backup.js",
+    "postpublish": "node ../../scripts/publish_recover.js"
   },
   "resolutions": {
     "antd": "4.x"

--- a/packages/gi-assets-graphscope/package.json
+++ b/packages/gi-assets-graphscope/package.json
@@ -25,7 +25,9 @@
     "remove:antd": "rm -rf ./node_modules/antd",
     "start": "father build --watch",
     "test": "jest",
-    "npm:publish": "npm run build && node ../../scripts/publish_backup.js && npm publish  && node ../../scripts/publish_recover.js"
+    "npm:publish": "npm publish",
+    "prepublishOnly": "npm run build && node ../../scripts/publish_backup.js",
+    "postpublish": "node ../../scripts/publish_recover.js"
   },
   "dependencies": {
     "@ant-design/icons": "^4.6.2",

--- a/packages/gi-assets-hugegraph/package.json
+++ b/packages/gi-assets-hugegraph/package.json
@@ -25,7 +25,9 @@
     "remove:antd": "rm -rf ./node_modules/antd",
     "start": "father build --watch",
     "test": "jest",
-    "npm:publish": "npm run build && node ../../scripts/publish_backup.js && npm publish  && node ../../scripts/publish_recover.js"
+    "npm:publish": "npm publish",
+    "prepublishOnly": "npm run build && node ../../scripts/publish_backup.js",
+    "postpublish": "node ../../scripts/publish_recover.js"
   },
   "dependencies": {
     "@ant-design/icons": "^4.6.2",

--- a/packages/gi-assets-neo4j/package.json
+++ b/packages/gi-assets-neo4j/package.json
@@ -25,7 +25,9 @@
     "remove:antd": "rm -rf ./node_modules/antd",
     "start": "father build --watch",
     "test": "jest",
-    "npm:publish": "npm run build && node ../../scripts/publish_backup.js && npm publish  && node ../../scripts/publish_recover.js"
+    "npm:publish": "npm publish",
+    "prepublishOnly": "npm run build && node ../../scripts/publish_backup.js",
+    "postpublish": "node ../../scripts/publish_recover.js"
   },
   "dependencies": {
     "@ant-design/icons": "^4.6.2",

--- a/packages/gi-assets-scene/package.json
+++ b/packages/gi-assets-scene/package.json
@@ -28,7 +28,9 @@
     "start": "npm run clean && father build --watch",
     "test": "jest",
     "build:umd:analysis": "webpack  --mode production  -c ../../webpack.config.js --env path=/packages/gi-assets-scene analysis=true",
-    "npm:publish": "npm run build && node ../../scripts/publish_backup.js && npm publish  && node ../../scripts/publish_recover.js"
+    "npm:publish": "npm publish",
+    "prepublishOnly": "npm run build && node ../../scripts/publish_backup.js",
+    "postpublish": "node ../../scripts/publish_recover.js"
   },
   "dependencies": {
     "3d-force-graph": "1.70.10",

--- a/packages/gi-assets-testing/package.json
+++ b/packages/gi-assets-testing/package.json
@@ -41,5 +41,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "private": true
 }

--- a/packages/gi-assets-tugraph/package.json
+++ b/packages/gi-assets-tugraph/package.json
@@ -22,7 +22,9 @@
     "remove:antd": "rm -rf ./node_modules/antd",
     "start": "npm run clean && father build --watch",
     "test": "jest",
-    "npm:publish": "npm run build && node ../../scripts/publish_backup.js && npm publish && node ../../scripts/publish_recover.js"
+    "npm:publish": "npm publish",
+    "prepublishOnly": "npm run build && node ../../scripts/publish_backup.js",
+    "postpublish": "node ../../scripts/publish_recover.js"
   },
   "resolutions": {
     "antd": "4.x"

--- a/packages/gi-common-components/package.json
+++ b/packages/gi-common-components/package.json
@@ -24,7 +24,9 @@
     "prettier": "prettier --write ./src/**/**/**/*.js",
     "start": "npm run clean && father build --watch",
     "test": "jest",
-    "npm:publish": "npm run build:es && node ../../scripts/publish_backup.js && npm publish && node ../../scripts/publish_recover.js"
+    "npm:publish": "npm publish",
+    "prepublishOnly": "npm run build:es && node ../../scripts/publish_backup.js",
+    "postpublish": "node ../../scripts/publish_recover.js"
   },
   "dependencies": {
     "@antv/g2plot": "^2.4.20",

--- a/packages/gi-mock-data/package.json
+++ b/packages/gi-mock-data/package.json
@@ -17,5 +17,6 @@
     "url": "https://github.com/antvis/G6VP.git"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "private": true
 }

--- a/packages/gi-portal/package.json
+++ b/packages/gi-portal/package.json
@@ -31,5 +31,6 @@
   },
   "devDependencies": {
     "react-spring": "^9.5.4"
-  }
+  },
+  "private": true
 }

--- a/packages/gi-sdk/package.json
+++ b/packages/gi-sdk/package.json
@@ -27,7 +27,9 @@
     "prettier": "prettier --write ./src/**/**/**/*.js",
     "start": "npm run clean && father build --watch",
     "test": "jest",
-    "npm:publish": "npm run build && node ../../scripts/publish_backup.js && npm publish && node ../../scripts/publish_recover.js"
+    "npm:publish": "npm publish",
+    "prepublishOnly": "npm run build && node ../../scripts/publish_backup.js",
+    "postpublish": "node ../../scripts/publish_recover.js"
   },
   "dependencies": {
     "@antv/gi-common-components": "workspace:*",

--- a/packages/gi-site/package.json
+++ b/packages/gi-site/package.json
@@ -78,5 +78,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "private": true
 }

--- a/packages/gi-theme-antd/package.json
+++ b/packages/gi-theme-antd/package.json
@@ -25,7 +25,8 @@
     "build:css": "webpack --env theme=light --config ./webpack.js && webpack  --env theme=dark  --config ./webpack.js && webpack  --env theme=ali  --config ./webpack.js",
     "clean:css": "rimraf dist",
     "clean": "rimraf es esm lib",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepublishOnly": "npm run build:es"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/my-custom-server/package.json
+++ b/packages/my-custom-server/package.json
@@ -37,5 +37,6 @@
   },
   "devDependencies": {
     "http-server": "^14.1.1"
-  }
+  },
+  "private": true
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   # all packages in subdirs of packages/ and components/
   - 'packages/**'
+  - '!packages/gi-cli/templates'


### PR DESCRIPTION
配置 [changeset](https://pnpm.io/using-changesets) 进行多包发布
发布方式如下：
1. 选择要发布的子包

```bash
pnpm changeset
```
<img width="376" alt="image" src="https://user-images.githubusercontent.com/25787943/236732270-cfef5e9d-21f3-4e41-8187-57f62740bcdb.png">

2. 选择版本号类型[major/minor/patch]
> 一般小版本就是 patch，直接回车两下就好。然后输入 `Summary`

<img width="500" alt="image" src="https://user-images.githubusercontent.com/25787943/236732475-672df77d-ef3f-4cc8-8191-7d0c28b8d730.png">

确认后再回车

<img width="600" alt="image" src="https://user-images.githubusercontent.com/25787943/236732552-2086c945-a8f7-4bb8-ae9c-721554b4fa1b.png">

此时暂存区可以看到生成的 changeset 文件(文件名随机)，记录了版本信息和描述

<img width="600" alt="image" src="https://user-images.githubusercontent.com/25787943/236732670-f102a034-6b14-4a14-b909-3da4c4415917.png">

3. 更新版本号并生成 changelog

```bash
pnpm changeset version
```

执行完成后可以看到所有需要发布的包，其 package.json 中版本号已经更新

4. 执行发布

```bash
pnpm publish -r
```

此步骤需要确保需要发布的子包都已经正确构建，为了简便，可以在其 `package.scripts` 中添加 `"prepublishOnly": "npm run build"` 来自动执行

5. 将发布过程产生的变动文件到主分支
