### PR TITLE
fix: 恢复pageLayout渲染逻辑

### DIFF
--- a/packages/gi-sdk/src/hooks/useComponents.tsx
+++ b/packages/gi-sdk/src/hooks/useComponents.tsx
@@ -11,7 +11,7 @@ const DEFAULT_GICC_LAYOUT = {
 };
 
 const useComponents = (state, propsComponentsCfg, ComponentAssets) => {
-  const { config, initializer, GICC_LAYOUT, components, GISDK_ID, HAS_GRAPH } = state;
+  const { config, initializer, GICC_LAYOUT, components, GISDK_ID } = state;
   const { components: stateComponentsCfg } = config;
   const ComponentCfgMap = propsComponentsCfg.concat(stateComponentsCfg).reduce((acc, curr) => {
     return {
@@ -23,10 +23,11 @@ const useComponents = (state, propsComponentsCfg, ComponentAssets) => {
   const { component: InitializerComponent } = ComponentAssets[initializer.id];
 
   const { props: InitializerProps } = ComponentCfgMap[initializer.id];
-  
+
   // 默认使用空布局，graph ready 了才使用 config.pageLayout，避免 pageLayout 中的资产在 graph 实例之前调用 graph
-  const layout = (HAS_GRAPH && ComponentAssets[config.pageLayout?.id || GICC_LAYOUT.id]) || DEFAULT_GICC_LAYOUT;
-  const { component: GICC_LAYOUT_COMPONENT } = layout;
+  const { component: GICC_LAYOUT_COMPONENT } = ComponentAssets[config.pageLayout?.id || GICC_LAYOUT.id] || {
+    component: DEFAULT_GICC_LAYOUT.component,
+  };
 
   // 页面布局组件的 props 从 context.config.pageLayout 中读取，统一 pageLayout 读写方式
   const { props: GICC_LAYOUT_PROPS } = config.pageLayout ||


### PR DESCRIPTION
### 问题
@yangzy0603 

变更 https://github.com/antvis/G6VP/pull/242 会导致以下问题：
并非所有 Layout 都需要等待 graph 初始化完成之后渲染。对于一个简单容器，这里容器组件并未加载 `props.children`， 因此画布不会进行初始化(不存在 graph 示例) ，进而导致出现容器组件无法渲染的问题。

```js
export default {
  info: {
    id: 'TestLayout',
    name: '测试布局',
    category: 'container-components',
    type: 'GICC_LAYOUT',
    desc: '测试布局',
    cover: 'http://xxxx.jpg',
  },
  component: () => <div>测试布局</div>,
  registerMeta: () => {
    return { containers: [] };
  },
};
```

**期望**
<img width="300" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/e75b6f25-1f98-4aa1-b939-91414def7783">

**实际情况**
<img width="600" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/3943318c-d83e-4bab-8861-5c4be550176e">

### 解决方案
> > "当前线上版本可以用「圣杯布局」的底部容器 + 「表格模式」试下复现"
这个问题我试了下并没有复现，不过合理的解决方案应该是放到组件内部去处理（类似于 React 的二次渲染逻辑）。即在 对「表格模式」组件进行修复。

如果从 GISDK 中进行限制（要求布局加载前必须存在`graph`示例），会降低组件开发的灵活性