### PR TITLE
fix: 资产列表重复选择同一个资产展示异常问题

### DIFF
--- a/packages/gi-site/src/pages/AssetsList/Detail.tsx
+++ b/packages/gi-site/src/pages/AssetsList/Detail.tsx
@@ -101,6 +101,7 @@ const Detail: React.FunctionComponent<DetailProps> = ({ data }) => {
             defaultExpandAll
             selectedKeys={state.selectedKeys || []}
             onSelect={keys => {
+              if (!keys.length) return;
               setState(preState => {
                 return {
                   ...preState,


### PR DESCRIPTION
- fix: 资产列表重复选择同一个资产展示异常问题
Tree 中重复选中为取消选中，增加取消判空
![image](https://github.com/antvis/G6VP/assets/114554589/9849cc2c-9684-4b2c-a559-145248e38a2f)
