### PR TITLE
fix: 容器配置AssetsCenter重复渲染问题

### DIFF
--- a/packages/gi-site/src/pages/Analysis/MetaPanel/ContainerPanel/AssetsCenter.tsx
+++ b/packages/gi-site/src/pages/Analysis/MetaPanel/ContainerPanel/AssetsCenter.tsx
@@ -35,7 +35,11 @@ interface AssetsCenterProps {
 
 const AssetsCenter: React.FunctionComponent<AssetsCenterProps> = props => {
   const { containerComponent, value = [], componentsMap, handleUpdate, handleClose } = props;
-  const { id: containerId, name: containerName, candidateAssets = [] } = containerComponent || {};
+  const { id: containerId, name: containerName } = containerComponent || {};
+
+  const candidateAssets = React.useMemo(() => {
+    return containerComponent && containerComponent.candidateAssets || [];
+  }, [containerComponent])
 
   const [state, setState] = useImmer({
     assets: candidateAssets, // AssetInfo[]


### PR DESCRIPTION
- fix: 容器配置AssetsCenter重复渲染问题
![image](https://github.com/antvis/G6VP/assets/114554589/cd92ae3f-0cf2-4df2-894a-2df45480c5d7)
