### PR TITLE
refactor: gi-site 若干细节优化

### DIFF
--- a/packages/gi-site/src/pages/Assets/Cards.tsx
+++ b/packages/gi-site/src/pages/Assets/Cards.tsx
@@ -1,6 +1,8 @@
-import { Card, Col, Row, Tag } from 'antd';
+import { Card, Col, Row, Tag, Typography } from 'antd';
 import * as React from 'react';
+
 const { Meta } = Card;
+const { Paragraph } = Typography;
 
 interface CardsProps {
   data: any;
@@ -114,9 +116,22 @@ const Cards: React.FunctionComponent<CardsProps> = props => {
 
           return (
             <Col xs={24} sm={24} md={12} lg={12} xl={8} xxl={6} key={global}>
-              <Card hoverable cover={<img alt="example" src={cover} />}>
+              <Card
+                hoverable
+                cover={<img alt="example" src={cover} style={{ objectFit: 'cover', aspectRatio: '16/9' }} />}
+              >
                 <div style={{ position: 'relative' }}>
-                  <Meta title={title} description={desc}></Meta>
+                  <Meta
+                    title={title}
+                    description={
+                      <Paragraph
+                        style={{ height: 45, margin: 0 }}
+                        ellipsis={{ rows: 2, expandable: false, tooltip: desc }}
+                      >
+                        {desc}
+                      </Paragraph>
+                    }
+                  ></Meta>
                   <Tag color={color} style={{ position: 'absolute', right: '0px', top: '2px' }}>
                     {`${group}@${version}`}
                   </Tag>

--- a/packages/gi-site/src/pages/Assets/Form.tsx
+++ b/packages/gi-site/src/pages/Assets/Form.tsx
@@ -1,0 +1,27 @@
+import { Form, Input, type FormInstance } from 'antd';
+import React from 'react';
+
+const { TextArea } = Input;
+
+export default ({ form }: { form: FormInstance }) => {
+  return (
+    <Form form={form} name="basic" labelCol={{ span: 4 }} wrapperCol={{ span: 20 }}>
+      <Form.Item label="Tnpm包名" name="name" rules={[{ required: true, message: 'Please input your package name!' }]}>
+        <Input placeholder="@antv/gi-assets-basic" />
+      </Form.Item>
+      <Form.Item
+        label="版本号"
+        name="version"
+        rules={[{ required: true, message: 'Please input your package version!' }]}
+      >
+        <Input placeholder="0.12.0" />
+      </Form.Item>
+      <Form.Item label="UMD名" name="global" rules={[{ required: true, message: 'Please input your password!' }]}>
+        <Input placeholder="GI_ASSETS_BASIC" />
+      </Form.Item>
+      <Form.Item label="CDN地址" name="url" rules={[{ required: true, message: 'Please input your password!' }]}>
+        <TextArea placeholder="https://gw.alipayobjects.com/os/lib/alipay/gi-assets-basic/0.12.0/dist/index.min.js" />
+      </Form.Item>
+    </Form>
+  );
+};

--- a/packages/gi-site/src/pages/Assets/Upload.tsx
+++ b/packages/gi-site/src/pages/Assets/Upload.tsx
@@ -1,8 +1,8 @@
 import { UploadOutlined } from '@ant-design/icons';
-import { Button, Form, Input, Modal, Tabs } from 'antd';
+import { Button, Form, Modal } from 'antd';
 import * as React from 'react';
-const { TabPane } = Tabs;
-const { TextArea } = Input;
+import PackageForm from './Form';
+
 const UploadAssets = () => {
   const [form] = Form.useForm();
 
@@ -40,28 +40,7 @@ const UploadAssets = () => {
       </Button>
 
       <Modal title="上传配置" visible={visible} onOk={handleOk} onCancel={handleCancel}>
-        <Form form={form} name="basic" labelCol={{ span: 8 }} wrapperCol={{ span: 16 }}>
-          <Form.Item
-            label="Tnpm包名"
-            name="name"
-            rules={[{ required: true, message: 'Please input your package name!' }]}
-          >
-            <Input placeholder="@antv/gi-assets-basic" />
-          </Form.Item>
-          <Form.Item
-            label="版本号"
-            name="version"
-            rules={[{ required: true, message: 'Please input your package version!' }]}
-          >
-            <Input placeholder="0.12.0" />
-          </Form.Item>
-          <Form.Item label="UMD名" name="global" rules={[{ required: true, message: 'Please input your password!' }]}>
-            <Input placeholder="GI_ASSETS_BASIC" />
-          </Form.Item>
-          <Form.Item label="CDN地址" name="url" rules={[{ required: true, message: 'Please input your password!' }]}>
-            <TextArea placeholder="https://gw.alipayobjects.com/os/lib/alipay/gi-assets-basic/0.12.0/dist/index.min.js" />
-          </Form.Item>
-        </Form>
+        <PackageForm form={form} />
       </Modal>
     </div>
   );

--- a/packages/gi-site/src/pages/Assets/index.tsx
+++ b/packages/gi-site/src/pages/Assets/index.tsx
@@ -2,7 +2,7 @@ import { DeploymentUnitOutlined, EnvironmentOutlined } from '@ant-design/icons';
 import { Empty, Space } from 'antd';
 import * as React from 'react';
 import SegmentedTabs from '../../components/SegmentedTabs';
-import { getAssetPackages, setDefaultAssetPackages } from '../../loader';
+import { getAssetPackages, setDefaultAssetPackages, type Package } from '../../loader';
 import Cards from './Cards';
 import './index.less';
 import PackageTable from './Table';
@@ -13,14 +13,13 @@ setDefaultAssetPackages();
 interface AssetsCenterProps {}
 
 const AssetsCenter: React.FunctionComponent<AssetsCenterProps> = props => {
-  const [state, setState] = React.useState({
+  const [state, setState] = React.useState<{ isReady: boolean; lists: Package[]; mode: 'card' | 'table' }>({
     isReady: false,
     lists: [],
-    mode: 'table' as 'card' | 'table',
+    mode: 'table',
   });
   React.useEffect(() => {
     const packages = getAssetPackages();
-    //@ts-ignore
     setState(preState => {
       return {
         ...preState,
@@ -29,11 +28,26 @@ const AssetsCenter: React.FunctionComponent<AssetsCenterProps> = props => {
       };
     });
   }, []);
+
   const handleChangeMode = val => {
     setState(preState => {
       return {
         ...preState,
         mode: val,
+      };
+    });
+  };
+
+  const handleEdit = (umd: string, val: Package) => {
+    const packages = getAssetPackages();
+    const packageIndex = packages.findIndex(item => item.global === umd);
+    packages[packageIndex] = val;
+
+    localStorage.setItem('GI_ASSETS_PACKAGES', JSON.stringify(packages));
+    setState(preState => {
+      return {
+        ...preState,
+        lists: [...packages],
       };
     });
   };
@@ -44,7 +58,7 @@ const AssetsCenter: React.FunctionComponent<AssetsCenterProps> = props => {
   }
   const renderMangeContainer = () => {
     if (mode === 'table') {
-      return <PackageTable data={lists}></PackageTable>;
+      return <PackageTable data={lists} onEdit={handleEdit}></PackageTable>;
     } else {
       return <Cards data={lists}></Cards>;
     }

--- a/packages/gi-site/src/pages/Dataset/Table.tsx
+++ b/packages/gi-site/src/pages/Dataset/Table.tsx
@@ -8,10 +8,12 @@ import {
   SendOutlined,
   TableOutlined,
 } from '@ant-design/icons';
-import { Button, Table, Tag, Tooltip } from 'antd';
+import { utils } from '@antv/gi-sdk';
+import { Button, Input, Table, Tag, Tooltip } from 'antd';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
-import { recoverDataset, recycleDataset } from '../../services/dataset';
+import { recoverDataset, recycleDataset, updateDataset } from '../../services/dataset';
+import { isNil } from '@antv/util';
 // import { getUid } from '../Workspace/utils';
 
 const styles = {
@@ -86,10 +88,17 @@ const DatasetTable = ({ data, queryData, recoverable = false, deletable = true }
     // window.open(`${window.location.origin}/#/workspace/${projectId}`);
     history.push(`/workbook/create?datasetId=${record.id}&templateId=TP_SIMPLE`);
   };
+
+  const handleRename = async (id: string, name: string) => {
+    const res = await updateDataset({ id, name });
+    if (res) queryData();
+  };
+
   const handleDelete = async record => {
     const res = await recycleDataset(record.id);
     if (res) queryData();
   };
+
   const handleView = record => {
     history.push(`/dataset/list/${record.id}`);
   };
@@ -109,9 +118,18 @@ const DatasetTable = ({ data, queryData, recoverable = false, deletable = true }
         const { type } = data;
         let tag = type === 'case' ? <Tag color="var(--primary-color)">官方案例</Tag> : '';
         return (
-          <div>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
             {tag}
-            {record}
+            <Input
+              defaultValue={record}
+              onBlur={e => {
+                const value = e.target.value;
+                if (!isNil(value) && value !== record) {
+                  handleRename(data.id, value);
+                }
+              }}
+              bordered={false}
+            />
           </div>
         );
       },
@@ -119,6 +137,7 @@ const DatasetTable = ({ data, queryData, recoverable = false, deletable = true }
     {
       title: '数据集ID',
       dataIndex: 'id',
+      width: 400,
       key: 'id',
     },
 
@@ -148,8 +167,19 @@ const DatasetTable = ({ data, queryData, recoverable = false, deletable = true }
     //   key: 'size',
     // },
     {
+      title: '创建时间',
+      dataIndex: 'gmtCreate',
+      key: 'gmtCreate',
+      width: 180,
+      render: (record, data) => {
+        if (record) return utils.time(record);
+        else return '-';
+      },
+      sorter: (a, b) => a.gmtCreate - b.gmtCreate,
+    },
+    {
       title: '操作',
-      width: '160px',
+      width: 160,
       render: record => {
         return (
           <span>

--- a/packages/gi-site/src/pages/Template/Cards.tsx
+++ b/packages/gi-site/src/pages/Template/Cards.tsx
@@ -1,10 +1,13 @@
 import { DeleteOutlined, EllipsisOutlined, ExportOutlined } from '@ant-design/icons';
-import { Card, Col, Dropdown, Row } from 'antd';
+import { Card, Col, Dropdown, Row, Typography } from 'antd';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { deleteDataset } from '../../services/dataset';
 import { ITemplate } from '../../services/typing';
+
 const { Meta } = Card;
+const { Paragraph } = Typography;
+
 interface ICardsProps {
   data: ITemplate[];
 }
@@ -60,7 +63,14 @@ const Cards: React.FunctionComponent<ICardsProps> = props => {
                 />
               }
             >
-              <Meta title={title} description={desc} />
+              <Meta
+                title={title}
+                description={
+                  <Paragraph style={{ margin: 0, height: 65 }} ellipsis={{ rows: 3, expandable: false, tooltip: desc }}>
+                    {desc}
+                  </Paragraph>
+                }
+              />
             </Card>
           </Col>
         );

--- a/packages/gi-site/src/pages/Workspace/Projects.tsx
+++ b/packages/gi-site/src/pages/Workspace/Projects.tsx
@@ -1,6 +1,7 @@
 import { DeleteOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 import { utils } from '@antv/gi-sdk';
-import { Button, Card, Col, Menu, Popconfirm, Row, Skeleton, Tooltip } from 'antd';
+import { isNil } from '@antv/util';
+import { Button, Card, Col, Input, Menu, Popconfirm, Row, Skeleton, Tooltip } from 'antd';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { useImmer } from 'use-immer';
@@ -133,7 +134,21 @@ const ProjectList: React.FunctionComponent<ProjectListProps> = props => {
               <Col key={id} xs={24} sm={24} md={12} lg={12} xl={8} xxl={6}>
                 <Card cover={Cover}>
                   <div style={{ position: 'relative' }}>
-                    <Meta title={name} description={description} />
+                    <Meta
+                      title={
+                        <Input
+                          defaultValue={name}
+                          bordered={false}
+                          onBlur={e => {
+                            const value = e.target.value;
+                            if (id && !isNil(value) && value !== name) {
+                              ProjectService.updateById(id, { name: value });
+                            }
+                          }}
+                        />
+                      }
+                      description={description}
+                    />
 
                     <div style={{ position: 'absolute', bottom: '0px', right: '0px' }}>
                       <Popconfirm

--- a/packages/gi-site/src/services/dataset.tsx
+++ b/packages/gi-site/src/services/dataset.tsx
@@ -3,6 +3,8 @@ import { GI_SITE } from './const';
 import DATASET_CASE from './initial.data/default.case';
 import { IDataset } from './typing';
 import { request } from './utils';
+import { deepMix } from '@antv/util';
+
 /**
  * 更新或保存指定项目
  * @param id 项目id
@@ -100,6 +102,27 @@ export const queryRecycleDatasetList = async () => {
       method: 'get',
     });
     return response.data.filter(item => item.type === 'user');
+  }
+};
+
+/**
+ * 更新数据集元信息
+ * @param record
+ */
+export const updateDataset = async record => {
+  const { id } = record;
+
+  if (GI_SITE.IS_OFFLINE) {
+    const item = await GI_DATASET_DB.getItem(id);
+    const newItem = deepMix({}, item, record);
+    if (item) GI_DATASET_DB.setItem(id, newItem);
+    return newItem;
+  } else {
+    const response = await request(`${GI_SITE.SERVICE_URL}/dataset/update`, {
+      method: 'post',
+      data: record,
+    });
+    return response.data;
   }
 };
 


### PR DESCRIPTION
关联 Issue: https://github.com/antvis/G6VP/issues/284

优化内容：
* 数据集支持重命名，添加创建时间列，支持排序
<img width="800" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/e06f52e0-d4cb-4478-9cca-dc598772f087">
<img width="800" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/5758080c-245d-465e-ae7e-1a6d76e912bf">

* 工作簿支持重命名
* 资产管理支持现有编辑，卡片模式样式统一
<img width="800" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/3c3bde39-38cc-4289-8046-7e4208cdb8e0">
<img width="1606" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/0d39b5f3-3c82-481a-b1a9-d045347d18bf">

* 模版卡片卡片样式统一
<img width="600" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/7c89fbd5-9a9d-48bb-90ae-c602528f75b7">

