### PR TITLE
fix: 修复导致 timebar 卡顿的问题

### DIFF
--- a/packages/gi-assets-scene/src/Timebar/control/index.tsx
+++ b/packages/gi-assets-scene/src/Timebar/control/index.tsx
@@ -36,6 +36,7 @@ const TimebarControl: React.FC<TimebarControlType> = props => {
   useEffect(() => {
     if (!rawDataRef.current && !isEmptyGraphData(data)) {
       rawDataRef.current = data;
+      setRenderData(dataTransform(data, type as any));
     }
   }, [data]);
 
@@ -43,7 +44,7 @@ const TimebarControl: React.FC<TimebarControlType> = props => {
   useEffect(() => {
     if (!rawDataRef.current || !timeGranularity) return;
     setRenderData(dataTransform(rawDataRef.current, type as any));
-  }, [data, field]);
+  }, [timeGranularity]);
 
   useEffect(() => {
     if (!timeRange || !rawDataRef.current) return;


### PR DESCRIPTION
迁移时 useEffect 依赖项错误导致 G2 Chart 重复渲染造成卡顿