### PR TITLE
fix: 修复timebar配置不生效问题

### DIFF
--- a/packages/gi-assets-scene/src/Timebar/Component.tsx
+++ b/packages/gi-assets-scene/src/Timebar/Component.tsx
@@ -1,8 +1,8 @@
 import { useContext, type GIGraphData } from '@antv/gi-sdk';
-import { Empty } from 'antd';
+import { Empty, message } from 'antd';
 import React from 'react';
 import TimebarControl from './control';
-import type { Aggregation, Speed, TimeFiled, TimeGranularity } from './types';
+import type { Aggregation, Speed, TimeGranularity } from './types';
 
 type TimebarProps = {
   /** 时间范围(时间戳) */
@@ -10,9 +10,9 @@ type TimebarProps = {
   /** 默认范围 */
   defaultTimeRange?: [number, number];
   /** 时间字段 */
-  timeField: TimeFiled;
+  timeField: string;
   /** 指标字段 */
-  yField?: string;
+  yField: string;
   /**
    * 时间粒度
    *
@@ -34,7 +34,7 @@ export const Timebar: React.FC<TimebarProps> = ({
   timeGranularity,
   speed,
 }) => {
-  const { data } = useContext();
+  const { data: graphData } = useContext();
 
   if (!timeField)
     return (
@@ -44,15 +44,24 @@ export const Timebar: React.FC<TimebarProps> = ({
       />
     );
 
+  const [xType, _timeField] = timeField.split(':');
+  const [yType, _yField] = yField.split(':');
+
+  if (xType !== yType) {
+    message.warning('请确保时间字段和指标字段同属于节点或边！');
+    return null;
+  }
+
   // 过滤出时间范围内的数据
   return (
     <TimebarControl
       aggregation={aggregation}
-      data={data as GIGraphData}
-      timeGranularity={timeGranularity}
-      timeField={timeField}
-      yField={yField}
+      graphData={graphData as GIGraphData}
       speed={speed}
+      timeField={_timeField}
+      timeGranularity={timeGranularity}
+      type={xType as any}
+      yField={_yField}
     />
   );
 };

--- a/packages/gi-assets-scene/src/Timebar/control/chart/index.tsx
+++ b/packages/gi-assets-scene/src/Timebar/control/chart/index.tsx
@@ -51,18 +51,7 @@ export type TimebarChartProps = {
 };
 
 export const TimebarChart = (props: TimebarChartProps) => {
-  const {
-    className,
-    data = [],
-    xField,
-    yField,
-    isTimeXField = true,
-    selection,
-    onSelection,
-    onReset,
-    aggregation,
-    granularity,
-  } = props;
+  const { className, data = [], xField, yField, selection, onSelection, onReset, aggregation, granularity } = props;
   const chartRef = useRef<Chart>();
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRenderingRef = useRef(true);
@@ -73,12 +62,11 @@ export const TimebarChart = (props: TimebarChartProps) => {
       case 'mean':
       case 'min':
       case 'median':
-        // yField 求均值统计
+      case 'sum':
         return {
           transform: [{ type: 'groupX', y: type }],
           encode: { x: xField, y: yField },
         };
-      // 分箱求和统计
       case 'count':
         return {
           transform: [{ type: 'groupX', y: 'count' }],
@@ -100,7 +88,6 @@ export const TimebarChart = (props: TimebarChartProps) => {
       state: { inactive: { fill: 'rgb(105 116 131)' } },
       animate: false,
       interaction: {
-        tooltip: false,
         brushXHighlight: {
           series: true,
           maskOpacity: 0.3,
@@ -163,7 +150,7 @@ export const TimebarChart = (props: TimebarChartProps) => {
     console.log(chartRef.current.options());
   }, [data, xField, yField, aggregation, granularity]);
 
-  // 同步更新高丽亮滑块
+  // 同步更新高亮滑块
   useEffect(() => {
     if (!chartRef.current || !selection || !selection[0] || !selection[1]) return;
 

--- a/packages/gi-assets-scene/src/Timebar/control/panel/helper.ts
+++ b/packages/gi-assets-scene/src/Timebar/control/panel/helper.ts
@@ -2,24 +2,20 @@ import dayjs from 'dayjs';
 import { maxBy, minBy } from 'lodash-es';
 import type { Selection, TimeGranularity } from '../../types';
 
-export const formatXAxis = (data: string | number, isTimeField: boolean, format: string) => {
-  if (isTimeField) {
-    if (dayjs(data, format).isValid()) {
-      return dayjs(data).format(format);
-    }
+export const formatXAxis = (data: string | number, format: string) => {
+  if (dayjs(data, format).isValid()) {
     return dayjs(data).format(format);
   }
-
-  return data;
+  return dayjs(data).format(format);
 };
 
-export const getFormatData = (data: Record<string, any>[], field: string, isTimeField: boolean, format: string) => {
+export const getFormatData = (data: Record<string, any>[], field: string, format: string) => {
   const newData = data
     .filter(item => !!item[field])
     .map(item => {
       return {
         ...item,
-        [field]: formatXAxis(item[field], isTimeField, format),
+        [field]: formatXAxis(item[field], format),
       };
     })
     .sort(function (a, b) {

--- a/packages/gi-assets-scene/src/Timebar/control/panel/index.tsx
+++ b/packages/gi-assets-scene/src/Timebar/control/panel/index.tsx
@@ -11,8 +11,7 @@ type Props = {
   aggregation: Aggregation;
   data: Record<string, any>[];
   defaultSelection?: Selection;
-  field: string;
-  isTimeXField: boolean;
+  timeField: string;
   onChangeTimeRange: (val: Selection) => void;
   onClear: () => void;
   speed?: Speed;
@@ -25,8 +24,7 @@ const TimebarPanel: React.FC<Props> = props => {
     aggregation,
     data: orignalData,
     defaultSelection,
-    field,
-    isTimeXField,
+    timeField,
     onChangeTimeRange,
     onClear,
     speed,
@@ -35,12 +33,12 @@ const TimebarPanel: React.FC<Props> = props => {
   } = props;
 
   const dataTimes = useMemo(() => {
-    const data = getFormatData(orignalData, field, isTimeXField, getTimeFormat(timeGranularity));
-    const line: string[] = data.map(item => item[field]);
+    const data = getFormatData(orignalData, timeField, getTimeFormat(timeGranularity));
+    const line: string[] = data.map(item => item[timeField]);
     const times = [...new Set(line)];
 
     return { data, times };
-  }, [orignalData, field, isTimeXField]);
+  }, [orignalData, timeField]);
 
   const [initSelection, setInitSelection] = useState<Selection>(getInitTimeRange(dataTimes.times));
   // 当前选中区间
@@ -97,7 +95,7 @@ const TimebarPanel: React.FC<Props> = props => {
       <div className="content-header">
         <div className="content-header-field">
           <ClockCircleOutlined />
-          {field}
+          {timeField}
         </div>
         <div className="content-header-time">
           <span>{selectionTime}</span>
@@ -107,9 +105,8 @@ const TimebarPanel: React.FC<Props> = props => {
       <TimebarChart
         className="chart"
         data={dataTimes.data}
-        xField={field}
+        xField={timeField}
         yField={yField}
-        isTimeXField={isTimeXField}
         selection={chartSelectedRange}
         aggregation={aggregation}
         granularity={timeGranularity}

--- a/packages/gi-assets-scene/src/Timebar/control/utils.ts
+++ b/packages/gi-assets-scene/src/Timebar/control/utils.ts
@@ -1,6 +1,6 @@
-import dayjs from 'dayjs';
 import type { GIGraphData } from '@antv/gi-sdk';
-import type { Selection, TimeGranularity } from '../types';
+import dayjs from 'dayjs';
+import type { FieldType, Selection, TimeGranularity } from '../types';
 import { getTimeFormat } from './panel/helper';
 
 export function timeParser(time: number): number;
@@ -17,7 +17,7 @@ export function timeParser(time: number | string, timeGranularity?: TimeGranular
  * 根据时间范围筛选图数据
  * @param data 图数据
  * @param range 时间范围
- * @param timeFieldEdge 时间字段(边)
+ * @param timeField 时间字段(边)
  * @param timeFieldNode 时间字段(节点，默认与边相同)
  * @returns
  */
@@ -25,60 +25,63 @@ export function dataFilter(
   data: GIGraphData,
   range: Selection,
   timeGranularity: TimeGranularity,
-  timeFieldEdge: string,
-  timeFieldNode: string = timeFieldEdge,
-): GIGraphData {
-  const { nodes = [], edges = [] } = data;
+  timeField: string,
+  type: FieldType,
+) {
+  const parser = time => timeParser(time, timeGranularity);
 
-  const parser = t => timeParser(t, timeGranularity);
-
-  const edgesFiltered = edges.filter(edge => {
-    const time = parser(edge.data[timeFieldEdge]);
+  const baseFiltrerd = (data[type] as any[]).filter(item => {
+    const time = parser(item.data[timeField]);
     return time >= parser(range[0]) && time <= parser(range[1]);
   });
 
-  let nodesFiltered: GIGraphData['nodes'] = [];
-  if (nodes.length > 0) {
-    if (nodes[0].data[timeFieldNode]) {
-      nodesFiltered = nodes.filter(node => {
-        const time = parser(node.data[timeFieldNode]);
+  let anotherFiltered: any[] = [];
+  const another: any[] = data[type === 'nodes' ? 'edges' : 'nodes'];
+  if (another.length > 0) {
+    if (another[0].data[timeField]) {
+      anotherFiltered = another.filter(item => {
+        const time = parser(item.data[timeField]);
         return time >= parser(range[0]) && time <= parser(range[1]);
       });
     }
-    // 如果节点数据中没有时间字段，根据边数据进行筛选
+    // 如果节点数据中没有时间字段，根据 base 数据进行筛选
     else {
-      const allNodesFromEdges = edgesFiltered.reduce((acc, cur) => {
-        acc.add(cur.source);
-        acc.add(cur.target);
-        return acc;
-      }, new Set<string>([]));
-      nodesFiltered = nodes.filter(node => allNodesFromEdges.has(node.id));
+      if (type === 'edges') {
+        const allNodesFromEdges = baseFiltrerd.reduce((acc, cur) => {
+          acc.add(cur.source);
+          acc.add(cur.target);
+          return acc;
+        }, new Set<string>([]));
+        anotherFiltered = another.filter(node => allNodesFromEdges.has(node.id));
+      } else {
+        const allEdgesFromNodes = baseFiltrerd.reduce((acc, cur) => {
+          acc.add(cur.id);
+          return acc;
+        }, new Set<string>([]));
+        anotherFiltered = another.filter(
+          edge => allEdgesFromNodes.has(edge.source) && allEdgesFromNodes.has(edge.target),
+        );
+      }
     }
   }
 
   return {
-    nodes: nodesFiltered,
-    edges: edgesFiltered,
-  };
+    [type]: baseFiltrerd,
+    [type === 'nodes' ? 'edges' : 'nodes']: anotherFiltered,
+  } as unknown as GIGraphData;
 }
 
 /**
  * 获取图数据中的时间范围
  */
-export function getTimeRange(
-  data: GIGraphData,
-  timeGranularity: TimeGranularity,
-  timeFieldEdge: string,
-  timeFieldNode: string = timeFieldEdge,
-) {
-  const { nodes, edges } = data;
+export function getTimeRange(data: Record<string, any>[], timeGranularity: TimeGranularity, timeField: string) {
   const parser = t => timeParser(t, timeGranularity);
-  const nodesTime = nodes
-    .map(node => node.data[timeFieldNode])
+
+  const times = data
+    .map(datum => datum[timeField])
     .filter(Boolean)
     .map(parser);
-  const edgesTime = edges.map(edge => edge.data[timeFieldEdge]).map(parser);
-  const times = [...nodesTime, ...edgesTime];
+
   const timeRange: Selection = [Math.min(...times), Math.max(...times)];
   return timeRange;
 }
@@ -87,6 +90,6 @@ export function getTimeRange(
  * 转换图数据为 G2 渲染数据
  * @param data 图数据
  */
-export function dataTransform(data: GIGraphData, type: 'nodes' | 'edges') {
+export function dataTransform(data: GIGraphData, type: FieldType) {
   return data[type].map(node => node.data);
 }

--- a/packages/gi-assets-scene/src/Timebar/registerMeta.ts
+++ b/packages/gi-assets-scene/src/Timebar/registerMeta.ts
@@ -1,8 +1,8 @@
 import { extra } from '@antv/gi-sdk';
-import { playbackSpeedList } from './control/animation/constants';
 import { TIME_GRANULARITY_LIST } from './constant';
-// import { getTimeRange } from './TimebarControl/utils';
+import { playbackSpeedList } from './control/animation/constants';
 import info from './info';
+import type { FieldType } from './types';
 
 const { deepClone, GIAC_CONTENT_METAS } = extra;
 const metas = deepClone(GIAC_CONTENT_METAS);
@@ -10,7 +10,7 @@ metas.GIAC_CONTENT.properties.GIAC_CONTENT.properties.title.default = info.name;
 metas.GIAC_CONTENT.properties.GIAC_CONTENT.properties.icon.default = info.icon;
 
 const registerMeta = ({ schemaData }) => {
-  const getProperties = (type: 'nodes' | 'edges', dataType?: string) => {
+  const getProperties = (type: FieldType, dataType?: string) => {
     return Object.entries<string>(
       schemaData[type].reduce((acc, cur) => {
         return {
@@ -44,7 +44,7 @@ const registerMeta = ({ schemaData }) => {
         { label: '边', options: getProperties('edges') },
       ],
       'x-decorator-props': {
-        tooltip: '非数值类型仅支持聚合计数',
+        tooltip: '非数值类型仅支持聚合计数\n确保和时间字段同属于节点或边',
       },
     },
     aggregation: {

--- a/packages/gi-assets-scene/src/Timebar/types.ts
+++ b/packages/gi-assets-scene/src/Timebar/types.ts
@@ -8,4 +8,6 @@ export type Selection = [string, string] | [number, number];
 
 export type TimeGranularity = 'year' | 'quarter' | 'month' | 'week' | 'day' | 'hour' | 'minute' | 'second' | number;
 
-export type TimeFiled = `${'nodes' | 'edges'}:${string}`;
+export type DataType = Record<string, any>[];
+
+export type FieldType = 'nodes' | 'edges';


### PR DESCRIPTION
之前不生效主要是因为在 GI 这边通过 `type:field` 的格式来区分节点字段和边字段
在传入 G2 schema 中为未进行处理导致找不到 encode 字段

<img width="1763" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/3173ab34-f067-4ad9-9483-c8116804a5a3">