### PR TITLE
feat: 分组规则支持属性路径，修复分组规则问题

### DIFF
--- a/packages/gi-common-components/src/GroupContainer/ExpressionGroup.tsx
+++ b/packages/gi-common-components/src/GroupContainer/ExpressionGroup.tsx
@@ -1,6 +1,12 @@
-import { DeleteOutlined, FieldNumberOutlined, FieldStringOutlined, PlusOutlined } from '@ant-design/icons';
-import { Button, Form, Col, Input, InputNumber, Row, Select } from 'antd';
-import React from 'react';
+import {
+  DeleteOutlined,
+  FieldNumberOutlined,
+  FieldStringOutlined,
+  FileTextOutlined,
+  PlusOutlined,
+} from '@ant-design/icons';
+import { Button, Col, Form, Input, InputNumber, Row, Select } from 'antd';
+import React, { useEffect, useState } from 'react';
 import { getOperatorList } from './utils';
 
 import './expressionGroup.less';
@@ -19,8 +25,33 @@ const ExpressionGroup: React.FunctionComponent<{
   name: string;
   options: any[];
 }> = ({ index, form, name, options }) => {
+  const [internalOptions, setInternalOptions] = useState(options);
+  // 支持自定义属性
+  const handleNameSearch = (value: string) => {
+    if (!value) {
+      setInternalOptions(options);
+      return;
+    }
+    const newOptions = options.filter(option => option.value.includes(value));
+    setInternalOptions([
+      {
+        label: value,
+        value,
+      },
+      ...newOptions,
+    ]);
+  };
+
+  const getPropertyType = (propertyName: string) => {
+    return options.find(option => option.value === propertyName)?.type || 'unknown';
+  };
+
+  useEffect(() => {
+    if (options?.length) setInternalOptions(options);
+  }, [options]);
+
   const content = (
-    <Form.Item name={[name, 'expressions']} label="属性过滤">
+    <Form.Item name={[name, 'expressions']} label="属性过滤" tooltip={'支持自定义属性路径，例: a.b.c'}>
       <Form.List name={[name, 'expressions']}>
         {(fields, { add, remove }) => {
           const { expressions } = form.getFieldValue('groups')[index] || {};
@@ -29,16 +60,23 @@ const ExpressionGroup: React.FunctionComponent<{
               {fields.map(({ key, name, ...restField }, conditionIndex) => {
                 const { name: property } = expressions[conditionIndex] || {};
                 // 根据类型判断 property 具体类型
-                const propertyType = (property || '').split('-')[1] || 'string';
+                const propertyType = getPropertyType(property);
                 return (
                   <Row align="middle" gutter={8} className="item" key={key}>
                     <Col span={2}>
                       {propertyType === 'string' && <FieldStringOutlined />}
-                      {(propertyType === 'long' || propertyType === 'double') && <FieldNumberOutlined />}
+                      {propertyType === 'number' && <FieldNumberOutlined />}
+                      {propertyType === 'unknown' && <FileTextOutlined />}
                     </Col>
                     <Col span={7}>
                       <Form.Item {...restField} name={[name, 'name']}>
-                        <Select size="small" style={{ width: '100%' }} options={options} />
+                        <Select
+                          size="small"
+                          showSearch
+                          onSearch={handleNameSearch}
+                          style={{ width: '100%' }}
+                          options={internalOptions}
+                        />
                       </Form.Item>
                     </Col>
                     <Col span={6}>

--- a/packages/gi-common-components/src/GroupContainer/index.tsx
+++ b/packages/gi-common-components/src/GroupContainer/index.tsx
@@ -61,10 +61,11 @@ const GroupContainer: React.FC<GroupContainerProps> = props => {
 
   // 构建属性列表
 
-  const propertyList = getAllkeysBySchema(schemaData, elementType)?.map(c => {
+  const propertyList = getAllkeysBySchema(schemaData, elementType)?.map(([c, t]) => {
     return {
       value: c,
       key: c,
+      type: t,
     };
   });
 

--- a/packages/gi-common-components/src/GroupContainer/utils.ts
+++ b/packages/gi-common-components/src/GroupContainer/utils.ts
@@ -1,125 +1,28 @@
-import { Expression } from './ExpressionGroup';
-import { Condition } from './index';
+export const getOperatorList = (type: 'string' | 'number' | 'boolean' | 'unknown') => {
+  const base = [
+    { label: '等于', value: 'eql' },
+    { label: '不等于', value: 'not-eql' },
+  ];
 
-export const getOperatorList = (type: 'long' | 'string' | 'double') => {
+  const str = [
+    { label: '包含', value: 'contain' },
+    { label: '不包含', value: 'not-contain' },
+  ];
+
+  const num = [
+    { label: '大于', value: 'gt' },
+    { label: '大于等于', value: 'gte' },
+    { label: '小于', value: 'lt' },
+    { label: '小于等于', value: 'lte' },
+  ];
+
   if (type === 'string') {
-    return [
-      {
-        label: '包含',
-        value: 'contain',
-      },
-      {
-        label: '不包含',
-        value: 'not-contain',
-      },
-      {
-        label: '等于',
-        value: 'eql',
-      },
-      {
-        label: '不等于',
-        value: 'not-eql',
-      },
-    ];
-  } else if (type === 'long' || type === 'double') {
-    return [
-      {
-        label: '等于',
-        value: 'eql',
-      },
-      {
-        label: '不等于',
-        value: 'not-eql',
-      },
-      {
-        label: '大于',
-        value: 'gt',
-      },
-      {
-        label: '大于等于',
-        value: 'gte',
-      },
-      {
-        label: '小于',
-        value: 'lt',
-      },
-      {
-        label: '小于等于',
-        value: 'lte',
-      },
-    ];
+    return [...base, ...str];
+  } else if (type === 'number') {
+    return [...base, ...num];
   } else if (type === 'boolean') {
-    return [
-      {
-        label: '等于',
-        value: 'eql',
-      },
-      {
-        label: '不等于',
-        value: 'not-eql',
-      },
-    ];
+    return base;
   }
 
-  return [];
-};
-
-export const formatProperties = (node: {
-  id: string;
-  data?: Record<string, string | number>;
-}): Record<string, string | number> => {
-  if (node.data) {
-    return node.data;
-  }
-  //@ts-ignore
-  return node || {};
-  // return node.data || {};
-};
-
-const filterByExpression = (data: Record<string, string | number>, expression: Expression): boolean => {
-  if (!expression) {
-    return false;
-  }
-  const { name: propertyName = '', operator, value } = expression;
-  const name = propertyName.split('-')[0];
-  let formatted: string | number = value;
-
-  if (operator === 'eql') {
-    return data[name] === formatted;
-  } else if (operator === 'not-eql') {
-    return data[name] !== formatted;
-  } else if (operator === 'contain') {
-    return `${data[name]}`.indexOf(`${formatted}`) > -1;
-  } else if (operator === 'not-contain') {
-    return `${data[name]}`.indexOf(`${formatted}`) === -1;
-  } else if (operator === 'gt') {
-    return Number(data[name]) > Number(formatted);
-  } else if (operator === 'gte') {
-    return Number(data[name]) >= Number(formatted);
-  } else if (operator === 'lt') {
-    return Number(data[name]) < Number(formatted);
-  } else if (operator === 'lte') {
-    return Number(data[name]) <= Number(formatted);
-  }
-
-  return false;
-};
-
-export const filterByTopRule = (node, rule: Condition) => {
-  const { logic, expressions } = rule;
-
-  // 未配置规则一律通过
-  if (!expressions || expressions.length === 0) {
-    return true;
-  }
-
-  return logic === true
-    ? expressions.every(item => filterByExpression(formatProperties(node), item))
-    : expressions.some(item => filterByExpression(formatProperties(node), item));
-};
-
-export const filterByRules = (nodes, rule) => {
-  return nodes.filter(node => {
-    return filterByTopRule(node, rule);
-  });
+  return [...base, ...str, ...num];
 };

--- a/packages/gi-common-components/src/Utils/getAllkeysBySchema.ts
+++ b/packages/gi-common-components/src/Utils/getAllkeysBySchema.ts
@@ -1,14 +1,14 @@
 export const getAllkeysBySchema = (schema, shapeType: 'nodes' | 'edges') => {
   try {
-    const keySet = new Set<[string, string]>();
+    const keyMap = new Map<string, string>();
     // 默认要把 nodeType/edgeType 加进来
-    keySet.add([shapeType === 'nodes' ? 'nodeType' : 'edgeType', 'string']);
+    keyMap.set(shapeType === 'nodes' ? 'nodeType' : 'edgeType', 'string');
     schema[shapeType].forEach(item => {
       Object.entries(item.properties as Record<string, string>).forEach(k => {
-        keySet.add(k);
+        keyMap.set(...k);
       });
     });
-    return [...keySet];
+    return Array.from(keyMap);
   } catch (error) {
     return [];
   }

--- a/packages/gi-common-components/src/Utils/getAllkeysBySchema.ts
+++ b/packages/gi-common-components/src/Utils/getAllkeysBySchema.ts
@@ -1,27 +1,14 @@
 export const getAllkeysBySchema = (schema, shapeType: 'nodes' | 'edges') => {
   try {
-    if (shapeType === 'nodes') {
-      const nodeKeySet = new Set();
-      // 默认要把 nodeType 加进来
-      nodeKeySet.add('nodeType');
-      schema.nodes.forEach(node => {
-        Object.keys(node.properties).forEach(k => {
-          nodeKeySet.add(k);
-        });
+    const keySet = new Set<[string, string]>();
+    // 默认要把 nodeType/edgeType 加进来
+    keySet.add([shapeType === 'nodes' ? 'nodeType' : 'edgeType', 'string']);
+    schema[shapeType].forEach(item => {
+      Object.entries(item.properties as Record<string, string>).forEach(k => {
+        keySet.add(k);
       });
-      return [...nodeKeySet];
-    }
-    if (shapeType === 'edges') {
-      const edgeKeySet = new Set();
-      // 默认要把 edgeType 加进来
-      edgeKeySet.add('edgeType');
-      schema.edges.forEach(edge => {
-        Object.keys(edge.properties).forEach(k => {
-          edgeKeySet.add(k);
-        });
-      });
-      return [...edgeKeySet];
-    }
+    });
+    return [...keySet];
   } catch (error) {
     return [];
   }

--- a/packages/gi-sdk/src/process/schema.ts
+++ b/packages/gi-sdk/src/process/schema.ts
@@ -15,7 +15,7 @@ export interface INodeSchema {
   nodeTypeKeyFromProperties: string;
   /** 业务数据（data）中的字段类型，目前不支持嵌套 */
   properties: {
-    [key: string]: 'string' | 'number' | 'date';
+    [key: string]: 'string' | 'number' | 'boolean';
   };
 }
 
@@ -30,7 +30,7 @@ export interface IEdgeSchema {
   targetNodeType?: string;
   /** 业务数据（data）中的字段类型，目前不支持嵌套 */
   properties: {
-    [key: string]: 'string' | 'number' | 'date';
+    [key: string]: 'string' | 'number' | 'boolean';
   };
 }
 


### PR DESCRIPTION
我看之前的逻辑，似乎是打算把属性名和属性类型通过 `-` 拼接在一起，不过实际上并没有做这步操作，导致全部属性规则都是 string 类型。