### PR TITLE
feat: support clear default infer element style

### DIFF
--- a/packages/gi-common-components/src/GroupContainer/index.less
+++ b/packages/gi-common-components/src/GroupContainer/index.less
@@ -1,7 +1,51 @@
 .gi-group-contaner {
-  .gi-sidebar-collapse {
-    background-color: rgba(0, 0, 0, 0);
+  .gi-style-form {
+    height: 100%;
+
+    .gi-style-form-list {
+      height: 100%;
+      display: flex;
+      flex-direction: column-reverse;
+      justify-content: space-between;
+
+      .gi-sidebar-collapse {
+        height: calc(100% - 40px);
+        overflow: auto;
+        background-color: rgba(0, 0, 0, 0);
+
+        &::-webkit-scrollbar {
+          display: none;
+        }
+      }
+
+      .gi-style-form-btn-group {
+        padding: 0 8px;
+        display: flex;
+        gap: 8px;
+
+        > :first-child {
+          flex-grow: 1;
+        }
+      }
+    }
+
+    .ant-form-item {
+      height: 100%;
+      & > .ant-form-item-row {
+        height: 100%;
+        & > .ant-form-item-control {
+          height: 100%;
+          & > .ant-form-item-control-input {
+            height: 100%;
+            & > .ant-form-item-control-input-content {
+              height: 100%;
+            }
+          }
+        }
+      }
+    }
   }
+
   .ant-formily-item {
     margin-bottom: 12px;
   }

--- a/packages/gi-common-components/src/GroupContainer/index.tsx
+++ b/packages/gi-common-components/src/GroupContainer/index.tsx
@@ -83,15 +83,23 @@ const GroupContainer: React.FC<GroupContainerProps> = props => {
     };
   });
 
+  /** 清除样式分组 */
+  const clear = () => {
+    form.setFieldsValue({
+      groups: [form.getFieldValue('groups')[0]],
+    });
+    onValuesChange({}, form.getFieldsValue());
+  };
+
   return (
     /** 让fixed定位从该容器开始 */
     <div className="gi-group-contaner" style={{ transform: 'scale(1)', height: '100%' }}>
       <Form
-        style={{ overflow: 'scroll', height: 'calc(100% - 30px)' }}
         initialValues={initValues}
         layout="vertical"
         form={form}
         onValuesChange={onValuesChange}
+        className="gi-style-form"
       >
         <Form.Item
           name="groups"
@@ -101,35 +109,28 @@ const GroupContainer: React.FC<GroupContainerProps> = props => {
           <Form.List name="groups">
             {(fields, { add, remove }) => {
               return (
-                <>
-                  <Button
-                    type="primary"
-                    style={{
-                      width: '100%',
-                      borderRadius: '4px',
-                      position: 'fixed',
-                      zIndex: 999,
-                      left: '0px',
-                      bottom: '12px',
-                    }}
-                    className="gi-tour-style-add-group"
-                    onClick={() => {
-                      const idx = fields.length + 1;
-                      const options = {
-                        ...defaultGroupOption,
-                        groupId: Math.random().toString(36).slice(-8),
-                        groupName: `自定义样式 ${idx}`,
-                      };
-                      add(options);
-                      setActiveKeys([...activeKeys, `${fields.length}`]);
-                    }}
-                    icon={<PlusOutlined />}
-                  >
-                    新增样式分组
-                  </Button>
-
+                <div className="gi-style-form-list">
+                  <div className="gi-style-form-btn-group">
+                    <Button
+                      type="primary"
+                      className="gi-tour-style-add-group"
+                      onClick={() => {
+                        const idx = fields.length + 1;
+                        const options = {
+                          ...defaultGroupOption,
+                          groupId: Math.random().toString(36).slice(-8),
+                          groupName: `自定义样式 ${idx}`,
+                        };
+                        add(options);
+                        setActiveKeys([...activeKeys, `${fields.length}`]);
+                      }}
+                      icon={<PlusOutlined />}
+                    >
+                      新增样式分组
+                    </Button>
+                    <Button onClick={clear}>重置</Button>
+                  </div>
                   <Collapse
-                    // collapsible="header"
                     className="gi-sidebar-collapse"
                     bordered={false}
                     onChange={onPanelChange}
@@ -235,7 +236,7 @@ const GroupContainer: React.FC<GroupContainerProps> = props => {
                       );
                     })}
                   </Collapse>
-                </>
+                </div>
               );
             }}
           </Form.List>


### PR DESCRIPTION
* 新增`重置`按钮，重置后仅保留默认样式
* 调整按钮样式，关闭滚动条

<img width="338" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/0c39c150-667d-4b08-815f-684d0b8a58a3">