### PR TITLE
fix: umd 模式导出内容缺失

### DIFF
--- a/packages/gi-site/.must.config.js
+++ b/packages/gi-site/.must.config.js
@@ -5,6 +5,14 @@ module.exports = {
     sourcePath: 'src',
     fileType: 'ts',
     prettier: true,
+    matchCopy: (text, path) => {
+      const isConsoleLog = /^console\.(log|warn|error|info)\(/gi.test(path.parentPath.toString());
+      // 简单正则先处理 匹配是否是注释字符串
+      const isCodeComment = /\/\/.*|\/*[sS]*?\*\//gi.test(path.parentPath.toString());
+      // ^\x00-\xff 表示匹配中文字符
+      const isChinese = /[^\x00-\xff]/.test(text);
+      return isChinese && !isConsoleLog && !isCodeComment;
+    },
     macro: {
       path: 'src/i18n',
       method: '$i18n.get({id:"$key$",dm:"$defaultMessage$"})',

--- a/packages/gi-site/src/hooks/useCodeSandbox.ts
+++ b/packages/gi-site/src/hooks/useCodeSandbox.ts
@@ -27,29 +27,33 @@ function getCSBData(opts) {
   const formatSchemaData = beautifyCode(JSON.stringify(schemaData));
 
   files['src/GI_EXPORT_FILES.ts'] = {
-    content: $i18n.get(
-      {
-        id: 'gi-site.src.hooks.useCodeSandbox.SupportingAssetsRequiredForDynamic',
-        dm: " \n      /** 动态请求需要的配套资产 **/\n      export const GI_ASSETS_PACKAGE = {GIASSETSPACKAGE}\n\n      /** G6VP 站点自动生成的配置 **/\n      export const GI_PROJECT_CONFIG = {GIPROJECTCONFIG};\n      \n      /** G6VP 站点选择服务引擎的上下文配置信息 **/\n      export const SERVER_ENGINE_CONTEXT = {SERVERENGINECONTEXT};\n\n      window['LOCAL_DATA_FOR_GI_ENGINE'] = {\n        data: {formatData},\n        schemaData: {formatSchemaData},\n      };\n    ",
-      },
-      {
-        GIASSETSPACKAGE: GI_ASSETS_PACKAGE,
-        GIPROJECTCONFIG: GI_PROJECT_CONFIG,
-        SERVERENGINECONTEXT: SERVER_ENGINE_CONTEXT,
-        formatData: formatData,
-        formatSchemaData: formatSchemaData,
-      },
-    ),
+    content: ` 
+      /** 动态请求需要的配套资产 **/
+      export const GI_ASSETS_PACKAGE = ${GI_ASSETS_PACKAGE};
+
+      /** G6VP 站点自动生成的配置 **/
+      export const GI_PROJECT_CONFIG = ${GI_PROJECT_CONFIG};
+      
+      /** G6VP 站点选择服务引擎的上下文配置信息 **/
+      export const SERVER_ENGINE_CONTEXT = ${SERVER_ENGINE_CONTEXT};
+
+      window['LOCAL_DATA_FOR_GI_ENGINE'] = {
+        data: ${formatData},
+        schemaData: ${formatSchemaData},
+      };
+    `,
   };
 
   files['src/index.tsx'] = {
-    content: $i18n.get(
-      {
-        id: 'gi-site.src.hooks.useCodeSandbox.AvoidConflictsBetweenMultipleVersions',
-        dm: '\n    // 因为没有做 external，避免多个版本react冲突，统一从window对象中获取\n    // import React from "react"\n    // import ReactDOM from "react-dom";\n\n    import {  GI_PROJECT_CONFIG, SERVER_ENGINE_CONTEXT,GI_ASSETS_PACKAGE } from "./GI_EXPORT_FILES";\n\n    {MYGRAPHSDK}\n    ',
-      },
-      { MYGRAPHSDK: MY_GRAPH_SDK },
-    ),
+    content: `
+    // 因为没有做 external，避免多个版本react冲突，统一从window对象中获取
+    // import React from "react";
+    // import ReactDOM from "react-dom";
+
+    import {  GI_PROJECT_CONFIG, SERVER_ENGINE_CONTEXT,GI_ASSETS_PACKAGE } from "./GI_EXPORT_FILES";
+
+    ${MY_GRAPH_SDK}
+    `,
   };
 
   files['package.json'] = {

--- a/packages/gi-site/src/i18n/index.ts
+++ b/packages/gi-site/src/i18n/index.ts
@@ -40,7 +40,7 @@ function change(langTag) {
  * @param {object} variable variable for id
  * @return {string} format message
  */
-function get(id, variable) {
+function get(id, variable = {}) {
   if (!intl) update();
   if (typeof id === 'string') {
     return stringFormat.format(


### PR DESCRIPTION
- 恢复被翻译脚本误翻译的文案
- 调整翻译脚本配置，防止注释写法的文案被误翻译，例如以下场景：
![image](https://github.com/antvis/G6VP/assets/114554589/f9880fe4-2d7e-4c8a-9624-9d259264b5b6)
