### PR TITLE
feat: color input support specific color type of rgba or hex by x-component-props

### DIFF
--- a/packages/gi-common-components/src/CommonStyleSetting/ColorInput/index.tsx
+++ b/packages/gi-common-components/src/CommonStyleSetting/ColorInput/index.tsx
@@ -6,6 +6,7 @@ import $i18n from '../../i18n';
 
 export interface IColorInputProps {
   value?: string;
+  colorType?: 'rgba' | 'hex';
   onChange?: (color: string) => void;
 }
 
@@ -32,12 +33,12 @@ const ColorInput: React.FC<IColorInputProps> = props => {
             overlayInnerStyle={{ padding: 0 }}
             getPopupContainer={() => container}
             content={
-              //@ts-ignore
               <SketchPicker
                 color={color}
-                onChange={({ rgb }) => {
-                  setColor(`rgba(${rgb.r},${rgb.g},${rgb.b},${rgb.a})`);
-                  props.onChange?.(`rgba(${rgb.r},${rgb.g},${rgb.b},${rgb.a})`);
+                onChange={({ rgb, hex }) => {
+                  const color = props.colorType === 'hex' ? hex : `rgba(${rgb.r},${rgb.g},${rgb.b},${rgb.a})`;
+                  setColor(color);
+                  props.onChange?.(color);
                 }}
               />
             }


### PR DESCRIPTION
ColorInput 新增 x-component-props 选项： colorType
默认值为 rgba
指定为 `hex` 时，返回颜色值为 16 进制格式

<img width="222" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/0a1a233c-0a33-4f0d-adc8-cd504638adfa">


```js
{
  title: 'Color',
  type: 'string',
  'x-decorator': 'FormItem',
  'x-component': 'ColorInput',
  default: DEFAULT_STYLE.color,
  'x-component-props': {
    colorType: 'hex',
  },
}
```