### PR TITLE
fix: add alternative value for defaultValue

### DIFF
--- a/packages/gi-sdk/src/process/services.ts
+++ b/packages/gi-sdk/src/process/services.ts
@@ -43,7 +43,7 @@ export const getServiceOptionsByEngineId = (services: GIService[], serviceId: st
     }) || options[0];
   return {
     options,
-    defaultValue: defaultValue.value,
+    defaultValue: defaultValue?.value || '',
   };
 };
 


### PR DESCRIPTION
https://github.com/antvis/G6VP/pull/418 对资产进行按需导出，导致 `getServiceOptionsByEngineId` options 可能为空，这里添加默认值