### PR TITLE
feat: support shortcuts

### DIFF
--- a/packages/gi-assets-basic/src/components/ZoomIn/Component.tsx
+++ b/packages/gi-assets-basic/src/components/ZoomIn/Component.tsx
@@ -1,5 +1,5 @@
 import type { IGIAC } from '@antv/gi-sdk';
-import { extra, useContext } from '@antv/gi-sdk';
+import { extra, useContext, useShortcuts } from '@antv/gi-sdk';
 import * as React from 'react';
 const { GIAComponent } = extra;
 export interface IProps {
@@ -9,6 +9,9 @@ export interface IProps {
 const ZoomIn: React.FunctionComponent<IProps> = props => {
   const { GIAC } = props;
   const { apis } = useContext();
+  useShortcuts(['ctrl+=', 'command+='], () => {
+    apis.handleZoomOut();
+  });
   return <GIAComponent GIAC={GIAC} onClick={() => apis.handleZoomOut()} />;
 };
 

--- a/packages/gi-assets-basic/src/components/ZoomOut/Component.tsx
+++ b/packages/gi-assets-basic/src/components/ZoomOut/Component.tsx
@@ -1,5 +1,5 @@
 import type { IGIAC } from '@antv/gi-sdk';
-import { extra, useContext } from '@antv/gi-sdk';
+import { extra, useContext, useShortcuts } from '@antv/gi-sdk';
 
 import * as React from 'react';
 const { GIAComponent } = extra;
@@ -10,6 +10,9 @@ export interface IProps {
 const ZoomOut: React.FunctionComponent<IProps> = props => {
   const { GIAC } = props;
   const { apis } = useContext();
+  useShortcuts(['ctrl+-', 'command+-'], () => {
+    apis.handleZoomIn();
+  });
   return <GIAComponent GIAC={GIAC} onClick={() => apis.handleZoomIn()} />;
 };
 

--- a/packages/gi-sdk/package.json
+++ b/packages/gi-sdk/package.json
@@ -37,6 +37,7 @@
     "@antv/gi-common-components": "workspace:*",
     "immer": "^9.0.7",
     "lodash-es": "^4.17.21",
+    "mousetrap": "^1.6.5",
     "react-intl": "^6.4.4",
     "size-sensor": "^1.0.1",
     "use-immer": "^0.9.0"
@@ -49,5 +50,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@types/mousetrap": "^1.6.11"
   }
 }

--- a/packages/gi-sdk/src/index.tsx
+++ b/packages/gi-sdk/src/index.tsx
@@ -33,6 +33,7 @@ export { default as EngineBanner } from './components/EngineBanner';
 export { default as EngineServer } from './components/EngineServer';
 export { default as Studio } from './components/Studio';
 export { Info } from './constants/info';
+export { Shortcuts, useShortcuts } from './utils';
 // export { default as Icon } from './components/Icon';
 /** export typing */
 export { COLORS, IEdgeSchema, INodeSchema } from './process/schema';

--- a/packages/gi-sdk/src/utils/index.ts
+++ b/packages/gi-sdk/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { Shortcuts, useShortcuts } from './shortcuts';

--- a/packages/gi-sdk/src/utils/shortcuts.ts
+++ b/packages/gi-sdk/src/utils/shortcuts.ts
@@ -1,0 +1,65 @@
+import { useEffect } from 'react';
+import Mousetrap from 'mousetrap';
+
+type Callback = Parameters<typeof Mousetrap.bind>[1];
+
+/**
+ * @description 绑定快捷键
+ * @description Bind a key to a callback function.
+ */
+export const Shortcuts = (() => {
+  const handlers: Map<Function, Callback> = new Map();
+
+  const on = (...args: Parameters<typeof Mousetrap.bind>) => {
+    const [key, callback, action] = args;
+    if (!key || !callback) return;
+
+    if (!handlers.has(callback)) {
+      const wrapper = (e: KeyboardEvent, combo: string) => {
+        e.preventDefault();
+        try {
+          callback?.(e, combo);
+        } catch {}
+      };
+      handlers.set(callback, wrapper);
+    }
+
+    Mousetrap.bind(key, handlers.get(callback)!, action);
+  };
+
+  const off = (...args: Parameters<typeof Mousetrap.unbind>) => {
+    const [key, action] = args;
+    if (!key) return;
+
+    Mousetrap.unbind(key, action);
+  };
+
+  const emit = (...args: Parameters<typeof Mousetrap.trigger>) => {
+    const [key, action] = args;
+    if (!key) return;
+
+    Mousetrap.trigger(key, action);
+  };
+
+  const reset = () => {
+    Mousetrap.reset();
+  };
+
+  return { on, off, emit, reset };
+})();
+
+/**
+ * @example
+ * useShortcuts('ctrl+s', () => {
+ *  console.log('save');
+ * });
+ */
+export const useShortcuts = (...args: Parameters<typeof Mousetrap.bind>) => {
+  useEffect(() => {
+    Shortcuts.on(...args);
+    return () => {
+      const [key, , action] = args;
+      Shortcuts.off(key, action);
+    };
+  }, []);
+};

--- a/packages/gi-site/src/components/Navbar/SaveWorkbook.tsx
+++ b/packages/gi-site/src/components/Navbar/SaveWorkbook.tsx
@@ -1,12 +1,13 @@
 import { SaveOutlined } from '@ant-design/icons';
+import { useShortcuts } from '@antv/gi-sdk';
 import { Graph } from '@antv/graphin';
 import { Button, notification, Tooltip } from 'antd';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
+import $i18n from '../../i18n';
 import { useContext } from '../../pages/Analysis/hooks/useContext';
 import * as ProjectServices from '../../services/project';
 import type { IProject } from '../../services/typing';
-import $i18n from '../../i18n';
 import './index.less';
 
 interface SaveWorkbookProps {
@@ -119,6 +120,10 @@ const SaveWorkbook: React.FunctionComponent<SaveWorkbookProps> = props => {
       message: $i18n.get({ id: 'gi-site.components.Navbar.SaveWorkbook.SaveFailed', dm: '保存失败' }),
     });
   };
+
+  useShortcuts(['ctrl+s', 'command+s'], () => {
+    handleSave();
+  });
 
   return (
     <Tooltip title={$i18n.get({ id: 'gi-site.components.Navbar.SaveWorkbook.SaveCanvas', dm: '保存画布' })}>

--- a/packages/gi-site/src/components/Navbar/Share.tsx
+++ b/packages/gi-site/src/components/Navbar/Share.tsx
@@ -1,3 +1,4 @@
+import { useShortcuts } from '@antv/gi-sdk';
 import { Button, notification } from 'antd';
 import * as React from 'react';
 import * as DatasetServices from '../../services/dataset';
@@ -57,6 +58,10 @@ const ShareProject: React.FunctionComponent<ShareProjectProps> = props => {
       });
     }
   };
+
+  useShortcuts(['ctrl+shift+s', 'command+shift+s'], () => {
+    handleClick();
+  });
 
   return (
     <div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -931,6 +931,9 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
+      mousetrap:
+        specifier: ^1.6.5
+        version: 1.6.5
       react:
         specifier: 17.x || 17
         version: 17.0.2
@@ -946,6 +949,10 @@ importers:
       use-immer:
         specifier: ^0.9.0
         version: 0.9.0(immer@9.0.21)(react@17.0.2)
+    devDependencies:
+      '@types/mousetrap':
+        specifier: ^1.6.11
+        version: 1.6.11
 
   packages/gi-sdk-app: {}
 
@@ -16649,6 +16656,10 @@ packages:
 
   /@types/mocha@2.2.48:
     resolution: {integrity: sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==}
+    dev: true
+
+  /@types/mousetrap@1.6.11:
+    resolution: {integrity: sha512-F0oAily9Q9QQpv9JKxKn0zMKfOo36KHCW7myYsmUyf2t0g+sBTbG3UleTPoguHdE1z3GLFr3p7/wiOio52QFjQ==}
     dev: true
 
   /@types/ms@0.7.31:


### PR DESCRIPTION
支持快捷键，从 `gi-sdk` 导出 `Shortcuts` 和 `useShortcuts`。
用法：
```ts
import { Shortcuts, useShortcuts } from '@antv/gi-sdk';

Shortcuts.on('command+s', ()=>{
  // do something
});

useShortcuts('command+s', ()=>{
  // do something
});
```

添加了默认快捷键：
`command+s`, `ctrl+s` ➡️ 保存项目
`command+shift+s`, `ctrl+shift+s` ➡️ 备份
`command+=`, `ctrl+=` ➡️ 放大画布
`command+-`, `ctrl+-` ➡️ 缩小画布

> ⚠️ 重复绑定时会覆盖掉已有的快捷键