### PR TITLE
chore: add weekly stats

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,0 +1,14 @@
+name: Weekly Stats
+
+on:
+  schedule:
+    - cron: '0 20 * * 4' # At 20:00 on Tuesday
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Aarebecca/stats@v1.2.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
每周四晚上20点统计每周活跃情况，报告默认会存到 `workflows/weekly-stats` 分支下，以当日日期命名

报告示例：

<img width="451" alt="image" src="https://github.com/antvis/G2/assets/25787943/bc68f814-4c2f-4523-bb23-dbd6db8c765d">
