### PR TITLE
fix: 修复右键菜单没出现的问题

### DIFF
--- a/packages/gi-assets-basic/src/components/ContextMenu/Container.tsx
+++ b/packages/gi-assets-basic/src/components/ContextMenu/Container.tsx
@@ -21,7 +21,7 @@ export interface ContextMenuProps {
 }
 
 const ContextMenu: React.FunctionComponent<ContextMenuProps> = props => {
-  const container = useRef() as RefObject<HTMLDivElement>;
+  const container = useRef<HTMLDivElement>(null);
   const { children, style, setItem } = props;
   const contextmenu = useContextMenu({
     container,

--- a/packages/gi-assets-basic/src/components/ContextMenu/Container.tsx
+++ b/packages/gi-assets-basic/src/components/ContextMenu/Container.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/require-default-props */
 import type { IG6GraphEvent } from '@antv/graphin';
-import React, { useEffect } from 'react';
+import React, { RefObject, useEffect, useRef } from 'react';
 import useContextMenu, { State } from './useContextMenu';
 
 export const defaultStyle: React.CSSProperties = {
@@ -20,9 +20,8 @@ export interface ContextMenuProps {
   style?: React.CSSProperties;
 }
 
-const container = React.createRef() as React.RefObject<HTMLDivElement>;
-
 const ContextMenu: React.FunctionComponent<ContextMenuProps> = props => {
+  const container = useRef() as RefObject<HTMLDivElement>;
   const { children, style, setItem } = props;
   const contextmenu = useContextMenu({
     container,


### PR DESCRIPTION
### 👀 PR includes

🐛 Bugfix

存在问题： 抽屉中GISDK生成的图销毁后导致画布上的右键菜单无法出现

![Kapture 2023-07-18 at 15 23 20](https://github.com/antvis/G6VP/assets/55794321/4798d941-da3d-4396-9a17-f2c076850011)

React.createRef 只能获取到最初渲染时的值，而不能获取到最新的值。改用 React.useRef 获取到最新的值。

效果图：

![Kapture 2023-07-18 at 15 21 17](https://github.com/antvis/G6VP/assets/55794321/9c8febee-58c1-4c56-878c-de357b6641d7)
