### PR TITLE
fix: fix issue that may cause ilouvain crash which object is not extensible

### DIFF
--- a/packages/gi-assets-algorithm/src/CommunityDetection/Component.tsx
+++ b/packages/gi-assets-algorithm/src/CommunityDetection/Component.tsx
@@ -198,6 +198,9 @@ const CommunityDetection: React.FunctionComponent<CommunityDetectionProps> = pro
     return {
       nodes: nodes.map(node => ({
         ...(node.data || {}),
+        properties: {
+          ...(node?.data?.properties || {}),
+        },
         label: node.label || node.data.label || node.data.name,
         id: node.id,
       })),

--- a/packages/gi-assets-algorithm/src/NodeImportance/Component.tsx
+++ b/packages/gi-assets-algorithm/src/NodeImportance/Component.tsx
@@ -234,7 +234,7 @@ const NodeImportance: React.FunctionComponent<NodeImportanceProps> = props => {
         //@TODO  Graphin类型的节点，需要和G6的规范保持一致，后续技术做改造
         graph.updateItem(nodeItem, {
           size,
-          oriSize: modelSize || style?.keyshape.size || 30,
+          oriSize: modelSize || style?.keyshape?.size || 30,
           // 兼容 graphin-circle
           style: {
             keyshape: {
@@ -267,7 +267,7 @@ const NodeImportance: React.FunctionComponent<NodeImportanceProps> = props => {
             //@TODO  Graphin类型的节点，需要和G6的规范保持一致，后续技术做改造
             graph.updateItem(edgeItem, {
               size: lineWidth,
-              oriSize: modelSize || style?.keyshape.size || 1,
+              oriSize: modelSize || style?.keyshape?.size || 1,
               // 兼容 graphin-line 类型边
               style: {
                 keyshape: {

--- a/packages/gi-assets-basic/src/components/LayoutSwitch/Component.tsx
+++ b/packages/gi-assets-basic/src/components/LayoutSwitch/Component.tsx
@@ -19,7 +19,7 @@ const LayoutSwitch: React.FunctionComponent<LayoutSwitchProps> = props => {
   const { layouts = {} } = assets;
 
   const handleClick = (layoutConfig: GILayoutConfig) => {
-    handleUpateHistory(layoutConfig, true, '');
+    handleUpdateHistory(layoutConfig, true, '');
     updateContext(draft => {
       draft.layout = layoutConfig.props;
       draft.config.layout = layoutConfig;
@@ -37,7 +37,7 @@ const LayoutSwitch: React.FunctionComponent<LayoutSwitchProps> = props => {
    * @param errorMsg 若失败，填写失败信息
    * @param value 查询语句
    */
-  const handleUpateHistory = (layoutConfig: GILayoutConfig, success: boolean, errorMsg?: string) => {
+  const handleUpdateHistory = (layoutConfig: GILayoutConfig, success: boolean, errorMsg?: string) => {
     const { props: layoutProps } = layoutConfig;
     updateHistory({
       componentId: 'LayoutSwitch',


### PR DESCRIPTION
`@antv/algorithm` 中 ilouvain 算法会修改原始图数据，写入 `node.properties.nodeType` 属性，可能会出现无法写入的情况，导致异常：

> Cannot add property nodeType, object is not extensible