### PR TITLE
fix(gi-site): 修复资产管理编辑修改不生效

### DIFF
--- a/packages/gi-site/src/pages/Assets/Form.tsx
+++ b/packages/gi-site/src/pages/Assets/Form.tsx
@@ -4,7 +4,7 @@ import $i18n from '../../i18n';
 
 const { TextArea } = Input;
 
-export default ({ form }: { form: FormInstance }) => {
+export default ({ form, mode = 'create' }: { form: FormInstance, mode?: 'edit' | 'create' }) => {
   return (
     <Form form={form} name="basic" labelCol={{ span: 4 }} wrapperCol={{ span: 20 }}>
       <Form.Item
@@ -26,7 +26,8 @@ export default ({ form }: { form: FormInstance }) => {
         name="global"
         rules={[{ required: true, message: 'Please input your password!' }]}
       >
-        <Input placeholder="GI_ASSETS_BASIC" />
+        {/* UMD名 作为资产的唯一性标识，不允许修改 */}
+        <Input placeholder="GI_ASSETS_BASIC"  disabled={mode === 'edit'}/>
       </Form.Item>
       <Form.Item
         label={$i18n.get({ id: 'gi-site.pages.Assets.Form.CdnAddress', dm: 'CDN地址' })}

--- a/packages/gi-site/src/pages/Assets/Table.tsx
+++ b/packages/gi-site/src/pages/Assets/Table.tsx
@@ -104,7 +104,7 @@ const PackageTable = ({ data, onEdit }) => {
           form.resetFields();
         }}
       >
-        <PackageForm form={form}></PackageForm>
+        <PackageForm form={form} mode='edit'></PackageForm>
       </Modal>
       <Table dataSource={data} columns={columns} />
     </>

--- a/packages/gi-site/src/pages/Assets/index.tsx
+++ b/packages/gi-site/src/pages/Assets/index.tsx
@@ -40,15 +40,13 @@ const AssetsCenter: React.FunctionComponent<AssetsCenterProps> = props => {
   };
 
   const handleEdit = (umd: string, val: Package) => {
-    const packages = getAssetPackages();
-    const packageIndex = packages.findIndex(item => item.global === umd);
-    packages[packageIndex] = val;
-
+    const packages = JSON.parse(localStorage.getItem('GI_ASSETS_PACKAGES') || '{}');
+    packages[umd] = val;
     localStorage.setItem('GI_ASSETS_PACKAGES', JSON.stringify(packages));
     setState(preState => {
       return {
         ...preState,
-        lists: [...packages],
+        lists: [...getAssetPackages()],
       };
     });
   };


### PR DESCRIPTION
- UMD 名作为资产全局唯一性标识 不允许修改，否则修改操作无法满足预期
![image](https://github.com/antvis/G6VP/assets/114554589/c3a3ea11-db6d-4674-9598-6fc8f143b43e)
- 修改后 localStorage 中的 GI_ASSETS_PACKAGES  仍保持 Record<umdName，assetInfo> 的数据结构，消费时再转换成 Array