### PR TITLE
fix: fix tabs pane label that cannot click

### DIFF
--- a/packages/gi-assets-algorithm/src/PatternMatch/Component.tsx
+++ b/packages/gi-assets-algorithm/src/PatternMatch/Component.tsx
@@ -859,20 +859,20 @@ const PatternMatch: React.FC<PatternMatchProps> = ({ style, controlledValues, on
         </div>
         <Tabs
           type="editable-card"
-          activeKey={`${activeKey}`}
+          activeKey={activeKey}
           onChange={setActiveKey}
           onEdit={onTabEdit}
           hideAdd
           style={{
             marginTop: panes.length > MAX_PATTERN_NUM - 1 ? '-4px' : '-40px',
           }}
-        >
-          {panes.map(pane => (
-            <TabPane tab={pane.title} key={pane.key} closable={panes.length > 1}>
-              {pane.content}
-            </TabPane>
-          ))}
-        </Tabs>
+          items={panes.map(({ key, title, content }) => ({
+            label: title,
+            key,
+            closable: panes.length > 1,
+            children: content,
+          }))}
+        />
       </div>
       <Row className="button-wrapper" justify="space-between">
         <Col span={6}>


### PR DESCRIPTION
<img width="308" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/71edf833-5e86-4600-9e80-b7e00b5b842a">

旧的写法有点问题，不太会选中Tab标头，换成新的写法就好了