### PR TITLE
feat: 容器配置增加 DIV 容器支持拖拽

### DIFF
--- a/packages/gi-assets-basic/package.json
+++ b/packages/gi-assets-basic/package.json
@@ -48,6 +48,7 @@
     "json2csv": "^5.0.7",
     "lodash": "^4.17.21",
     "nanoid": "^4.0.0",
+    "react-draggable": "^4.4.5",
     "use-immer": "^0.9.0"
   },
   "peerDependencies": {

--- a/packages/gi-assets-basic/src/components/OperatorHeader/WrapContainer.tsx
+++ b/packages/gi-assets-basic/src/components/OperatorHeader/WrapContainer.tsx
@@ -77,6 +77,7 @@ export interface ContainerTypeProps {
   getContainer: HTMLDivElement;
   containerAnimate?: boolean;
   containerDraggable?: boolean;
+  dragHandle: 'header' | 'divContainer';
 }
 
 const ContainerType = (props: ContainerTypeProps) => {
@@ -96,6 +97,7 @@ const ContainerType = (props: ContainerTypeProps) => {
     getContainer,
     containerAnimate,
     containerDraggable,
+    dragHandle,
   } = props;
 
   const placement = POSITION_MAP[containerPlacement] as 'right' | 'left' | 'top' | 'bottom';
@@ -151,6 +153,7 @@ const ContainerType = (props: ContainerTypeProps) => {
       animate={containerAnimate}
       getContainer={getContainer}
       draggable={containerDraggable}
+      dragHandle={dragHandle}
     >
       {children}
     </DivContainer>
@@ -182,6 +185,7 @@ const WrapContainer = (Component, componentId, GISDK_ID) => {
       containerPlacement,
       containerAnimate,
       containerDraggable = false,
+      dragHandle,
     } = GIAC_CONTENT;
 
     const [containerVisible, setVisible] = React.useState(defaultVisible);
@@ -249,6 +253,7 @@ const WrapContainer = (Component, componentId, GISDK_ID) => {
             getContainer={ContainerDOM}
             containerAnimate={containerAnimate}
             containerDraggable={containerDraggable}
+            dragHandle={dragHandle}
           >
             <Component {...ComponentProps} visible={containerVisible} onClose={onClose} onOpen={onOpen} />
           </ContainerType>,

--- a/packages/gi-assets-basic/src/components/OperatorHeader/WrapContainer.tsx
+++ b/packages/gi-assets-basic/src/components/OperatorHeader/WrapContainer.tsx
@@ -76,6 +76,7 @@ export interface ContainerTypeProps {
   GISDK_ID: string;
   getContainer: HTMLDivElement;
   containerAnimate?: boolean;
+  containerDraggable?: boolean;
 }
 
 const ContainerType = (props: ContainerTypeProps) => {
@@ -94,6 +95,7 @@ const ContainerType = (props: ContainerTypeProps) => {
     GISDK_ID,
     getContainer,
     containerAnimate,
+    containerDraggable,
   } = props;
 
   const placement = POSITION_MAP[containerPlacement] as 'right' | 'left' | 'top' | 'bottom';
@@ -147,6 +149,8 @@ const ContainerType = (props: ContainerTypeProps) => {
       offset={offset}
       containerPlacement={containerPlacement}
       animate={containerAnimate}
+      getContainer={getContainer}
+      draggable={containerDraggable}
     >
       {children}
     </DivContainer>
@@ -177,6 +181,7 @@ const WrapContainer = (Component, componentId, GISDK_ID) => {
       containerMaskClosable = false,
       containerPlacement,
       containerAnimate,
+      containerDraggable = false,
     } = GIAC_CONTENT;
 
     const [containerVisible, setVisible] = React.useState(defaultVisible);
@@ -243,6 +248,7 @@ const WrapContainer = (Component, componentId, GISDK_ID) => {
             GISDK_ID={GISDK_ID}
             getContainer={ContainerDOM}
             containerAnimate={containerAnimate}
+            containerDraggable={containerDraggable}
           >
             <Component {...ComponentProps} visible={containerVisible} onClose={onClose} onOpen={onOpen} />
           </ContainerType>,

--- a/packages/gi-assets-basic/src/components/UIComponents/DivContainer/index.tsx
+++ b/packages/gi-assets-basic/src/components/UIComponents/DivContainer/index.tsx
@@ -1,8 +1,11 @@
 import { CloseOutlined } from '@ant-design/icons';
 import { utils } from '@antv/gi-sdk';
-import { Button } from 'antd';
-import * as React from 'react';
+import { Button, Divider } from 'antd';
+import React from 'react';
+import Draggable from 'react-draggable';
 import './index.less';
+import ReactDOM from 'react-dom';
+
 const POSITION_MAP = {
   LT: 'top',
   LB: 'left',
@@ -20,6 +23,8 @@ export interface ContainerTypeProps {
   onClose: () => void;
   title: string;
   animate?: boolean;
+  getContainer?: HTMLDivElement;
+  draggable?: boolean;
 }
 
 const DivContainer: React.FunctionComponent<ContainerTypeProps> = props => {
@@ -33,6 +38,8 @@ const DivContainer: React.FunctionComponent<ContainerTypeProps> = props => {
     onClose,
     title,
     animate,
+    getContainer,
+    draggable = false,
   } = props;
 
   const styles = utils.getPositionStyles(containerPlacement, offset);
@@ -49,7 +56,8 @@ const DivContainer: React.FunctionComponent<ContainerTypeProps> = props => {
     : {
         display: visible ? 'block' : 'none',
       };
-  return (
+
+  const DivContainer = (
     <div
       style={{
         width: containerWidth,
@@ -60,15 +68,26 @@ const DivContainer: React.FunctionComponent<ContainerTypeProps> = props => {
       }}
       className={`gi-panel-div ${classes}`}
     >
-      <div className="header">
+      <div className="header" style={{ cursor: draggable ? 'move' : 'default' }}>
         <div className="title"> {title}</div>
         <div className="close">
           <Button icon={<CloseOutlined />} type="text" onClick={onClose}></Button>
         </div>
       </div>
+      <Divider style={{ margin: 0 }} />
       <div className="body">{children}</div>
     </div>
   );
+
+  if (draggable) {
+    return ReactDOM.createPortal(
+      <Draggable handle=".header" bounds="parent">
+        {DivContainer}
+      </Draggable>,
+      getContainer!,
+    );
+  }
+  return DivContainer;
 };
 
 export default DivContainer;

--- a/packages/gi-assets-basic/src/components/UIComponents/DivContainer/index.tsx
+++ b/packages/gi-assets-basic/src/components/UIComponents/DivContainer/index.tsx
@@ -59,7 +59,7 @@ const DivContainer: React.FunctionComponent<ContainerTypeProps> = props => {
         display: visible ? 'block' : 'none',
       };
   const nodeRef = React.useRef(null);
-
+  
   const DivContainer = (
     <div
       ref={nodeRef}

--- a/packages/gi-assets-basic/src/components/UIComponents/DivContainer/index.tsx
+++ b/packages/gi-assets-basic/src/components/UIComponents/DivContainer/index.tsx
@@ -25,6 +25,7 @@ export interface ContainerTypeProps {
   animate?: boolean;
   getContainer?: HTMLDivElement;
   draggable?: boolean;
+  dragHandle?: 'header' | 'divContainer';
 }
 
 const DivContainer: React.FunctionComponent<ContainerTypeProps> = props => {
@@ -40,6 +41,7 @@ const DivContainer: React.FunctionComponent<ContainerTypeProps> = props => {
     animate,
     getContainer,
     draggable = false,
+    dragHandle = 'header',
   } = props;
 
   const styles = utils.getPositionStyles(containerPlacement, offset);
@@ -56,17 +58,20 @@ const DivContainer: React.FunctionComponent<ContainerTypeProps> = props => {
     : {
         display: visible ? 'block' : 'none',
       };
+  const nodeRef = React.useRef(null);
 
   const DivContainer = (
     <div
+      ref={nodeRef}
       style={{
         width: containerWidth,
         height: containerHeight,
         boxShadow: '6px 0 16px -8px rgb(0 0 0 / 8%), 9px 0 28px 0 rgb(0 0 0 / 5%), 12px 0 48px 16px rgb(0 0 0 / 3%)',
+        cursor: draggable && dragHandle === 'divContainer' ? 'move' : 'default',
         ...styles,
         ...displayStyle,
       }}
-      className={`gi-panel-div ${classes}`}
+      className={`divContainer gi-panel-div ${classes}`}
     >
       <div className="header" style={{ cursor: draggable ? 'move' : 'default' }}>
         <div className="title"> {title}</div>
@@ -81,7 +86,7 @@ const DivContainer: React.FunctionComponent<ContainerTypeProps> = props => {
 
   if (draggable) {
     return ReactDOM.createPortal(
-      <Draggable handle=".header" bounds="parent">
+      <Draggable handle={`.${dragHandle}`} bounds="parent">
         {DivContainer}
       </Draggable>,
       getContainer!,

--- a/packages/gi-sdk/src/components/Studio.tsx
+++ b/packages/gi-sdk/src/components/Studio.tsx
@@ -4,6 +4,7 @@ import { getCombineServices, loaderCombinedAssets } from '../process';
 import { loader } from '../process/loaderAssets';
 import registerIconFonts from '../process/registerIconFonts';
 import Loading from './Loading';
+import $i18n from '../i18n';
 
 export interface Project {
   dataset: {
@@ -46,7 +47,11 @@ export interface StudioProps {
 }
 
 const Studio: React.FunctionComponent<StudioProps> = props => {
-  const { id, service, loadingText = '正在加载图应用...' } = props;
+  const {
+    id,
+    service,
+    loadingText = $i18n.get({ id: 'sdk.src.components.Studio.LoadingGraphApplication', dm: '正在加载图应用...' }),
+  } = props;
   const [state, setState] = React.useState({
     isReady: false,
     assets: null,

--- a/packages/gi-sdk/src/components/const.ts
+++ b/packages/gi-sdk/src/components/const.ts
@@ -193,14 +193,14 @@ const GIAC_CONTENT = {
           default: false,
         },
         containerDraggable: {
-          title: '可拖拽（仅DIV有效）',
+          title: $i18n.get({ id: 'sdk.src.components.const.DraggableValidOnlyForDiv', dm: '可拖拽（仅DIV有效）' }),
           type: 'boolean',
           'x-decorator': 'FormItem',
           'x-component': 'Switch',
           default: false,
         },
         dragHandle: {
-          title: '拖拽生效区域',
+          title: $i18n.get({ id: 'sdk.src.components.const.DragAndDropTheEffective', dm: '拖拽生效区域' }),
           type: 'string',
           'x-decorator': 'FormItem',
           'x-component': 'Select',
@@ -208,11 +208,11 @@ const GIAC_CONTENT = {
             options: [
               {
                 value: 'header',
-                label: '仅标题',
+                label: $i18n.get({ id: 'sdk.src.components.const.TitleOnly', dm: '仅标题' }),
               },
               {
                 value: 'divContainer',
-                label: '整个容器',
+                label: $i18n.get({ id: 'sdk.src.components.const.EntireContainer', dm: '整个容器' }),
               },
             ],
           },

--- a/packages/gi-sdk/src/components/const.ts
+++ b/packages/gi-sdk/src/components/const.ts
@@ -192,6 +192,13 @@ const GIAC_CONTENT = {
           'x-component': 'Switch',
           default: false,
         },
+        containerDraggable: {
+          title: '可拖拽（仅DIV有效）',
+          type: 'boolean',
+          'x-decorator': 'FormItem',
+          'x-component': 'Switch',
+          default: false,
+        },
         containerPlacement: {
           title: $i18n.get({ id: 'sdk.src.components.const.ContainerLocation', dm: '容器位置' }),
           type: 'string',

--- a/packages/gi-sdk/src/components/const.ts
+++ b/packages/gi-sdk/src/components/const.ts
@@ -199,6 +199,25 @@ const GIAC_CONTENT = {
           'x-component': 'Switch',
           default: false,
         },
+        dragHandle: {
+          title: '拖拽生效区域',
+          type: 'string',
+          'x-decorator': 'FormItem',
+          'x-component': 'Select',
+          'x-component-props': {
+            options: [
+              {
+                value: 'header',
+                label: '仅标题',
+              },
+              {
+                value: 'divContainer',
+                label: '整个容器',
+              },
+            ],
+          },
+          default: 'header',
+        },
         containerPlacement: {
           title: $i18n.get({ id: 'sdk.src.components.const.ContainerLocation', dm: '容器位置' }),
           type: 'string',

--- a/packages/gi-sdk/src/i18n/strings/en-US.json
+++ b/packages/gi-sdk/src/i18n/strings/en-US.json
@@ -93,5 +93,10 @@
   "sdk.src.process.aggregateEdges.SummaryChildrenlength": "Summary:{childrenLength}",
   "sdk.src.process.schema.OfficialNode": "Official node",
   "sdk.src.process.schema.DefaultStyle": "Default style",
-  "sdk.src.process.schema.OfficialSide": "Official side"
+  "sdk.src.process.schema.OfficialSide": "Official side",
+  "sdk.src.components.Studio.LoadingGraphApplication": "Loading Graph application...",
+  "sdk.src.components.const.DraggableValidOnlyForDiv": "Draggable (valid only for DIV)",
+  "sdk.src.components.const.DragAndDropTheEffective": "Drag and drop the effective area",
+  "sdk.src.components.const.TitleOnly": "Title only",
+  "sdk.src.components.const.EntireContainer": "Entire container"
 }

--- a/packages/gi-sdk/src/i18n/strings/zh-CN.json
+++ b/packages/gi-sdk/src/i18n/strings/zh-CN.json
@@ -93,5 +93,10 @@
   "sdk.src.process.aggregateEdges.SummaryChildrenlength": "汇总：{childrenLength} 条",
   "sdk.src.process.schema.OfficialNode": "官方节点",
   "sdk.src.process.schema.DefaultStyle": "默认样式",
-  "sdk.src.process.schema.OfficialSide": "官方边"
+  "sdk.src.process.schema.OfficialSide": "官方边",
+  "sdk.src.components.Studio.LoadingGraphApplication": "正在加载图应用...",
+  "sdk.src.components.const.DraggableValidOnlyForDiv": "可拖拽（仅DIV有效）",
+  "sdk.src.components.const.DragAndDropTheEffective": "拖拽生效区域",
+  "sdk.src.components.const.TitleOnly": "仅标题",
+  "sdk.src.components.const.EntireContainer": "整个容器"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,6 +336,9 @@ importers:
       react-dom:
         specifier: 17.x
         version: 17.0.2(react@17.0.2)
+      react-draggable:
+        specifier: ^4.4.5
+        version: 4.4.5(react-dom@17.0.2)(react@17.0.2)
       use-immer:
         specifier: ^0.9.0
         version: 0.9.0(immer@9.0.0)(react@17.0.2)
@@ -13808,7 +13811,7 @@ packages:
       react: '>=16.8 || 17'
       react-dom: '>=16.8'
     dependencies:
-      prop-types: 15.7.2
+      prop-types: 15.8.1
       react: 17.0.2
       react-dom: 16.14.0(react@17.0.2)
       tippy.js: 4.3.5
@@ -13821,7 +13824,7 @@ packages:
       react: '>=16.8 || 17'
       react-dom: '>=16.8'
     dependencies:
-      prop-types: 15.7.2
+      prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       tippy.js: 4.3.5
@@ -23119,7 +23122,7 @@ packages:
       object-assign: 4.1.1
     dev: false
 
-  /create-react-context@0.2.3(prop-types@15.7.2)(react@17.0.2):
+  /create-react-context@0.2.3(prop-types@15.8.1)(react@17.0.2):
     resolution: {integrity: sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==}
     peerDependencies:
       prop-types: ^15.0.0
@@ -23127,7 +23130,7 @@ packages:
     dependencies:
       fbjs: 0.8.18
       gud: 1.0.0
-      prop-types: 15.7.2
+      prop-types: 15.8.1
       react: 17.0.2
     dev: true
 
@@ -41942,10 +41945,10 @@ packages:
     dependencies:
       buble: 0.19.8
       core-js: 2.6.12
-      create-react-context: 0.2.3(prop-types@15.7.2)(react@17.0.2)
+      create-react-context: 0.2.3(prop-types@15.8.1)(react@17.0.2)
       dom-iterator: 1.0.0
       prismjs: 1.6.0
-      prop-types: 15.7.2
+      prop-types: 15.8.1
       react: 17.0.2
       react-dom: 16.14.0(react@17.0.2)
       unescape: 0.2.0
@@ -41960,10 +41963,10 @@ packages:
     dependencies:
       buble: 0.19.8
       core-js: 2.6.12
-      create-react-context: 0.2.3(prop-types@15.7.2)(react@17.0.2)
+      create-react-context: 0.2.3(prop-types@15.8.1)(react@17.0.2)
       dom-iterator: 1.0.0
       prismjs: 1.6.0
-      prop-types: 15.7.2
+      prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       unescape: 0.2.0
@@ -42107,7 +42110,7 @@ packages:
       react-dom: '>=16.3.3'
     dependencies:
       perfect-scrollbar: 1.5.5
-      prop-types: 15.7.2
+      prop-types: 15.8.1
       react: 17.0.2
       react-dom: 16.14.0(react@17.0.2)
     dev: true
@@ -42119,7 +42122,7 @@ packages:
       react-dom: '>=16.3.3'
     dependencies:
       perfect-scrollbar: 1.5.5
-      prop-types: 15.7.2
+      prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: true
@@ -45938,7 +45941,7 @@ packages:
       css-to-react-native: 2.3.2
       memoize-one: 5.2.1
       merge-anything: 2.4.4
-      prop-types: 15.7.2
+      prop-types: 15.8.1
       react: 17.0.2
       react-dom: 16.14.0(react@17.0.2)
       react-is: 16.13.1
@@ -45964,7 +45967,7 @@ packages:
       css-to-react-native: 2.3.2
       memoize-one: 5.2.1
       merge-anything: 2.4.4
-      prop-types: 15.7.2
+      prop-types: 15.8.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       react-is: 16.13.1


### PR DESCRIPTION
容器配置中针对 DIV 容器新增 **可拖拽（仅DIV有效）** 以及 **拖拽生效区域**。

![image](https://github.com/antvis/G6VP/assets/55794321/f9d6459b-e881-4703-8fd9-80e5cf6a7f83)

效果如下：

![Kapture 2023-07-25 at 17 12 09](https://github.com/antvis/G6VP/assets/55794321/d21cfb90-fc28-46d7-93d9-4a20861be425)
