### PR TITLE
fix: fix issue that set wrong graph size when pattern match unmounted

### DIFF
--- a/packages/gi-assets-algorithm/src/PatternMatch/Component.tsx
+++ b/packages/gi-assets-algorithm/src/PatternMatch/Component.tsx
@@ -102,6 +102,10 @@ const PatternMatch: React.FC<PatternMatchProps> = ({ style, controlledValues, on
 
   useEffect(() => {
     if (!graph || graph.destroyed) return;
+
+    // init previousSize
+    previousSize = { width: graph.getWidth(), height: graph.getHeight() };
+
     const handleClickEdge = e => {
       const mode = graph.getCurrentMode();
       if (mode !== PATTERN_MATCH_MODE) return;


### PR DESCRIPTION
之前问题：

抽屉里的模式匹配销毁后（切换到其他组件），会设置画布为 previousSize，但 previousSize 初始值为 500*500，并没有更新为画布实际的尺寸。

https://github.com/antvis/G6VP/blob/4324266bab3c7db13e28fe3aeb788611c8b4e4cd/packages/gi-assets-algorithm/src/PatternMatch/Component.tsx#L531-L541

https://github.com/antvis/G6VP/assets/25787943/d6817c5b-a242-4aea-9dad-13407f8a057c

