### PR TITLE
fix: 若未配置 timeout 和 limit 可配，则 gremlinQuery 不自动增加相关约束

### DIFF
--- a/packages/gi-assets-advance/package.json
+++ b/packages/gi-assets-advance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/gi-assets-advance",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "G6VP 高级资产包",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/gi-assets-advance/src/components/GremlinQuery/Component.tsx
+++ b/packages/gi-assets-advance/src/components/GremlinQuery/Component.tsx
@@ -79,10 +79,10 @@ const GremlinQueryPanel: React.FC<IGremlinQueryProps> = ({
     }
 
     let gremlinCode = `${editorValue}`;
-    if (limit && !editorValueHasLimit) {
+    if (isShowLimit && limit && !editorValueHasLimit) {
       gremlinCode = `${gremlinCode}.limit(${limit})`;
     }
-    if (timeout && !editorValueHasTimeout) {
+    if (isShowTimeout && timeout && !editorValueHasTimeout) {
       gremlinCode = `${gremlinCode.substring(0, 1)}.with('evaluationTimeout', ${timeout})${gremlinCode.substring(1)}`;
     }
 


### PR DESCRIPTION
fix: 若未配置 timeout 和 limit 可配，则 gremlinQuery 不自动增加相关约束