### PR TITLE
fix: fix layout of placeholder in small size

### DIFF
--- a/packages/gi-assets-basic/src/components/Placeholder/Component.tsx
+++ b/packages/gi-assets-basic/src/components/Placeholder/Component.tsx
@@ -6,6 +6,8 @@ import './index.less';
 export interface LoadingProps {
   img?: string;
   text?: string;
+  textColor: string;
+  spacing: number;
   width: number;
 }
 
@@ -15,6 +17,8 @@ const Placeholder: React.FunctionComponent<LoadingProps> = props => {
     width = 200,
     img = 'https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*1BGfQ78mW4kAAAAAAAAAAAAADmJ7AQ/original',
     text,
+    spacing,
+    textColor,
   } = props;
 
   const { data, largeGraphData, largeGraphLimit } = context;
@@ -40,13 +44,13 @@ const Placeholder: React.FunctionComponent<LoadingProps> = props => {
     );
   }
   return (
-    <div className="gi-placeholder" style={{ width: `${width}px` }}>
+    <div className="gi-placeholder" style={{ width: `${width}px`, gap: spacing }}>
       {img && (
         <div className="image-wrapper">
           <img src={img} width={width} />
         </div>
       )}
-      <span>{text}</span>
+      <span style={{ color: textColor }}>{text}</span>
     </div>
   );
 };

--- a/packages/gi-assets-basic/src/components/Placeholder/Component.tsx
+++ b/packages/gi-assets-basic/src/components/Placeholder/Component.tsx
@@ -25,7 +25,7 @@ const Placeholder: React.FunctionComponent<LoadingProps> = props => {
   }
   if (largeGraphData) {
     return (
-      <div className="gi-placeholader" style={{ width: `${width}px` }}>
+      <div className="gi-placeholder" style={{ width: `${width}px` }}>
         {img && <img src={img} width={width} />}
         {$i18n.get({
           id: 'basic.components.Placeholder.Component.TheNodeSizeOfThe',
@@ -40,9 +40,13 @@ const Placeholder: React.FunctionComponent<LoadingProps> = props => {
     );
   }
   return (
-    <div className="gi-placeholader" style={{ width: `${width}px` }}>
-      {img && <img src={img} width={width} />}
-      {text}
+    <div className="gi-placeholder" style={{ width: `${width}px` }}>
+      {img && (
+        <div className="image-wrapper">
+          <img src={img} width={width} />
+        </div>
+      )}
+      <span>{text}</span>
     </div>
   );
 };

--- a/packages/gi-assets-basic/src/components/Placeholder/index.less
+++ b/packages/gi-assets-basic/src/components/Placeholder/index.less
@@ -1,14 +1,29 @@
-.gi-placeholader {
+.gi-placeholder {
   position: absolute;
   top: 50%;
   left: 50%;
-  min-width: 220px;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
   text-align: center;
   user-select: none;
   pointer-events: none;
   transform: translate3d(-50%, -50%, 0);
 
-  img {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  .image-wrapper {
+    overflow: auto;
     width: 100%;
+
+    img {
+      max-width: 100%;
+      max-height: 100%;
+      width: auto;
+      height: auto;
+    }
   }
 }

--- a/packages/gi-assets-basic/src/components/Placeholder/registerMeta.ts
+++ b/packages/gi-assets-basic/src/components/Placeholder/registerMeta.ts
@@ -18,6 +18,20 @@ export default () => {
         dm: '开始你的图分析应用～',
       }),
     },
+    textColor: {
+      type: 'string',
+      title: $i18n.get({ id: 'basic.components.Placeholder.registerMeta.TextColor', dm: '文本颜色' }),
+      'x-component': 'ColorInput',
+      'x-decorator': 'FormItem',
+      default: '#999',
+    },
+    spacing: {
+      type: 'number',
+      title: $i18n.get({ id: 'basic.components.Placeholder.registerMeta.Spacing', dm: '间距' }),
+      'x-component': 'NumberPicker',
+      'x-decorator': 'FormItem',
+      default: 8,
+    },
     width: {
       type: 'number',
       title: $i18n.get({ id: 'basic.components.Placeholder.registerMeta.Width', dm: '宽度' }),

--- a/packages/gi-assets-basic/src/i18n/strings/en-US.json
+++ b/packages/gi-assets-basic/src/i18n/strings/en-US.json
@@ -287,6 +287,8 @@
   "basic.components.Placeholder.registerMeta.ImageAddress": "Image address",
   "basic.components.Placeholder.registerMeta.Text": "Text",
   "basic.components.Placeholder.registerMeta.StartYourGraphAnalysisApplication": "Start your graph analysis application ~",
+  "basic.components.Placeholder.registerMeta.TextColor": "Text Color",
+  "basic.components.Placeholder.registerMeta.Spacing": "Spacing",
   "basic.components.Placeholder.registerMeta.Width": "Width",
   "basic.components.PropertiesPanel.PropertiesDetail.CompareWithOtherAttribute": "Compared to other values of the attribute {key}, the current attribute value {value} has a {importance} occurrence rate, which may contain significant information and deserves attention",
   "basic.components.PropertiesPanel.PropertiesDetail.VeryLow": " very low",

--- a/packages/gi-assets-basic/src/i18n/strings/zh-CN.json
+++ b/packages/gi-assets-basic/src/i18n/strings/zh-CN.json
@@ -296,6 +296,8 @@
   "basic.components.Placeholder.registerMeta.ImageAddress": "图片地址",
   "basic.components.Placeholder.registerMeta.Text": "文本",
   "basic.components.Placeholder.registerMeta.StartYourGraphAnalysisApplication": "开始你的图分析应用～",
+  "basic.components.Placeholder.registerMeta.TextColor": "文本颜色",
+  "basic.components.Placeholder.registerMeta.Spacing": "间距",
   "basic.components.Placeholder.registerMeta.Width": "宽度",
   "basic.components.PropertiesPanel.PropertiesDetail.MostAttributeValuesOfThe": "属性 “{key}” 的大部分属性值具有相同出现次数，而当前属性值 “{value}” 出现此处大于平均出现次数，值得关注",
   "basic.PropertiesPanel.Statistic.ChartCard.XAxisField": "X轴字段",


### PR DESCRIPTION
`gi-assets-basic` placeholder 修正
* 样式修正，修复了在 GISDK 容器尺寸较小时 placeholder 溢出的问题

<img width="493" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/7e047ca4-ce6e-4fb6-8eec-78e58a9507f5">

* 修正了 className 命名拼写错误问题
* 新增`文本颜色`和`间距`配置项

<img width="440" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/2763d119-de61-4780-bc50-4ea11947ce5e">
