### PR TITLE
chore: use browser as history type

### DIFF
--- a/packages/gi-site/.umirc.ts
+++ b/packages/gi-site/.umirc.ts
@@ -61,7 +61,7 @@ export default {
   hash: true,
   favicon: 'https://gw.alipayobjects.com/zos/bmw-prod/b9a0f537-3768-445d-aa39-ff49de82124a.svg',
   history: {
-    type: 'hash',
+    type: 'browser',
   },
   alias: {
     '@': './src',

--- a/packages/gi-site/src/components/Sidebar/index.tsx
+++ b/packages/gi-site/src/components/Sidebar/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-import React, { memo } from 'react';
-import { getSearchParams } from '../utils';
+import React, { memo, useEffect } from 'react';
 import './index.less';
 interface Option {
   /** 导航图标 */
@@ -19,8 +18,14 @@ interface SidebarProps {
 
 const Sidebar: React.FunctionComponent<SidebarProps> = props => {
   const { options, collapse, onChange } = props;
-  const { searchParams, path } = getSearchParams(window.location);
-  const nav = searchParams.get('nav') || 'style';
+
+  const nav = location.hash.replace('#', '');
+
+  useEffect(() => {
+    if (!nav) return;
+    const opt = options.find(opt => opt.id === nav);
+    opt && onChange?.(opt);
+  }, []);
 
   return (
     <ul className="gi-sidebar">
@@ -32,8 +37,7 @@ const Sidebar: React.FunctionComponent<SidebarProps> = props => {
           <li
             key={id}
             onClick={() => {
-              searchParams.set('nav', id);
-              window.location.hash = `${path}?${searchParams.toString()}`;
+              window.location.hash = `#${id}`;
               onChange(opt);
             }}
             className={`${className} gi-intro-nav-${id}`}

--- a/packages/gi-site/src/components/utils.ts
+++ b/packages/gi-site/src/components/utils.ts
@@ -2,6 +2,7 @@
  * 复制功能
  * @param {String} value
  */
+
 export function copyText(value: string) {
   const input = document.createElement('input');
   document.body.appendChild(input);
@@ -22,18 +23,12 @@ export function copyText(value: string) {
  */
 
 /**
- * 获取hash上的search对象
+ * 获取 search 参数对象
  * @param location
  * @returns
  */
-export const getSearchParams = (location: Location) => {
-  const { hash } = location;
-  const [path, search] = hash.split('?');
-  const searchParams = new URLSearchParams(search);
-  return {
-    path,
-    searchParams,
-  };
+export const getSearchParams = () => {
+  return new URLSearchParams(window.location.search);
 };
 
 /**

--- a/packages/gi-site/src/pages/Analysis/MetaPanel/index.tsx
+++ b/packages/gi-site/src/pages/Analysis/MetaPanel/index.tsx
@@ -64,22 +64,24 @@ const MetaPanel = props => {
     }
   }, [value]);
 
-  const { component: Component } = navbarOptionsMap[value];
+  const { component: Component } = navbarOptionsMap[value] || {};
 
   return (
     <div className="gi-config-panel" style={{ height: state.panelHeight || '100%' }}>
-      <Component
-        {...props}
-        updateContext={updateContext}
-        context={context}
-        setPanelHeight={height =>
-          setState(draft => {
-            draft.panelHeight = height;
-          })
-        }
-        setPanelWidth={setPanelWidth}
-        collapse={collapse}
-      />
+      {Component && (
+        <Component
+          {...props}
+          updateContext={updateContext}
+          context={context}
+          setPanelHeight={height =>
+            setState(draft => {
+              draft.panelHeight = height;
+            })
+          }
+          setPanelWidth={setPanelWidth}
+          collapse={collapse}
+        />
+      )}
     </div>
   );
 };

--- a/packages/gi-site/src/pages/Analysis/index.tsx
+++ b/packages/gi-site/src/pages/Analysis/index.tsx
@@ -6,7 +6,6 @@ import React, { memo, useRef, useState } from 'react';
 import { Sidebar } from '../../components';
 import Loading from '../../components/Loading';
 import Navbar from '../../components/Navbar/WorkbookNav';
-import { getSearchParams } from '../../components/utils';
 import $i18n from '../../i18n';
 import { queryAssets } from '../../services/assets';
 import { queryDatasetInfo } from '../../services/dataset';
@@ -66,8 +65,7 @@ const Analysis = props => {
         draft.isReady = false;
       });
       /** 从地址栏上选择默认展示的tab */
-      const { searchParams } = getSearchParams(window.location);
-      const activeNavbar = searchParams.get('nav') || 'style';
+      const activeNavbar = location.hash.replace('#', '');
 
       /** 根据 projectId 获取项目的信息  */
       const { config, activeAssetsKeys, themes, name, datasetId } = (await ProjectServices.getById(

--- a/packages/gi-site/src/pages/Analysis/utils.tsx
+++ b/packages/gi-site/src/pages/Analysis/utils.tsx
@@ -104,7 +104,7 @@ export const getUpdateGISite =
  * @returns
  */
 export const useEngineSystemDirectConnect = async (projectId: string) => {
-  const { searchParams } = getSearchParams(window.location);
+  const searchParams = getSearchParams();
   const IS_ENGINE_SYSTEM_DIRECT_CONNECT = projectId === 'ENGINE_SYSTEM_DIRECT_CONNECT';
   const datasetInfoString = searchParams.get('datasetInfo');
   // 如果 URL中 直接带有这个参数，则直接解析使用
@@ -122,7 +122,7 @@ export const useEngineSystemDirectConnect = async (projectId: string) => {
 };
 
 export const useDatasetInfo = async datasetId => {
-  const { searchParams } = getSearchParams(window.location);
+  const searchParams = getSearchParams();
   const datasetInfoString = searchParams.get('datasetInfo');
   let datasetInfo;
   // 如果 URL中 直接带有这个参数，则直接解析使用

--- a/packages/gi-site/src/pages/Workspace/Projects.tsx
+++ b/packages/gi-site/src/pages/Workspace/Projects.tsx
@@ -128,7 +128,7 @@ const ProjectList: React.FunctionComponent<ProjectListProps> = props => {
                 src={cover || `${window['GI_PUBLIC_PATH']}image/empty_workbook.png`}
                 style={{ cursor: 'pointer', height: '100%' }}
                 onClick={() => {
-                  history.push(`/workspace/${id}?nav=style`);
+                  history.push(`/workspace/${id}#style`);
                 }}
               />
             </div>


### PR DESCRIPTION
history type 使用 `browser`

为 `hash` 时无法正常通过 URLSearchParams 取得URL查询参数

> 侧边栏选项仍然采用 hash

改为 `browser` 后未发现异常

![Aug-22-2023 23-35-12](https://github.com/antvis/G6VP/assets/25787943/f24e0c1a-44c8-4c3c-9fd4-0a2271d95654)
