### PR TITLE
refactor: adjust LayoutConfig type definition

### DIFF
--- a/packages/gi-sdk/src/typing.ts
+++ b/packages/gi-sdk/src/typing.ts
@@ -308,7 +308,7 @@ export type GIAssets = Partial<{
 }>;
 export interface LayoutConfig {
   // 支持的布局类型，默认为 force
-  type?: 'preset' | 'graphin-force' | 'force' | 'grid' | 'dagre' | 'circular' | 'concentric';
+  type?: 'preset' | 'graphin-force' | 'force' | 'grid' | 'dagre' | 'circular' | 'concentric' | string;
   [key: string]: any;
 }
 export interface GILayoutConfig {


### PR DESCRIPTION
调整 LayoutConfig 类型定义

在注册了自定义布局后，会出现类型错误，因此这里加上 `string` 类型支持