### PR TITLE
refactor: node selection support config label formatter; style adjust

### DIFF
--- a/packages/gi-assets-algorithm/src/NodesSimilarity/Component.tsx
+++ b/packages/gi-assets-algorithm/src/NodesSimilarity/Component.tsx
@@ -1,6 +1,7 @@
 import { ReloadOutlined } from '@ant-design/icons';
 import { nodesCosineSimilarity } from '@antv/algorithm';
 import { NodeSelectionWrap } from '@antv/gi-common-components';
+import type { NodeFormatProps } from '@antv/gi-common-components';
 import { useContext } from '@antv/gi-sdk';
 import type { GraphinData } from '@antv/graphin';
 import { Button, Empty, Form, message } from 'antd';
@@ -9,7 +10,7 @@ import React, { memo, useEffect, useState } from 'react';
 import $i18n from '../i18n';
 import './index.less';
 import SimilarityResultTable from './resultTable';
-export interface CommunityDiscoveryProps {
+export interface CommunityDiscoveryProps extends NodeFormatProps {
   style?: React.CSSProperties;
   controlledValues?: {
     algorithm: string;
@@ -29,7 +30,7 @@ interface ResData {
   similarNodes: any[] | undefined;
 }
 const CommunityDiscovery: React.FC<CommunityDiscoveryProps> = props => {
-  const { controlledValues, style = {}, onOpen, nodeSelectionMode, nodeLabel } = props;
+  const { controlledValues, style = {}, onOpen, nodeSelectionMode, nodeLabel, labelFormat } = props;
   const { data, graph, updateHistory } = useContext();
   const [communityAlgo, setCommunityAlgo] = useState(NodesSimilarityAlgorithm.nodesConsineSimilarity);
   const [initData, setInitData] = useState<GraphinData>({ nodes: [], edges: [] });
@@ -286,6 +287,7 @@ const CommunityDiscovery: React.FC<CommunityDiscoveryProps> = props => {
                 },
               ]}
               data={data.nodes}
+              labelFormat={labelFormat}
               nodeLabel={nodeLabel}
               nodeSelectionMode={nodeSelectionMode}
             />

--- a/packages/gi-assets-algorithm/src/NodesSimilarity/registerMeta.ts
+++ b/packages/gi-assets-algorithm/src/NodesSimilarity/registerMeta.ts
@@ -1,6 +1,6 @@
 import { extra } from '@antv/gi-sdk';
 import info from './info';
-import { NodeSelectionMode } from '@antv/gi-common-components/lib/NodeSelectionWrap';
+import { NodeSelectionMode, getNodeFormatOption } from '@antv/gi-common-components';
 import $i18n from '../i18n';
 const { deepClone, GIAC_CONTENT_METAS } = extra;
 const metas = deepClone(GIAC_CONTENT_METAS);
@@ -29,7 +29,8 @@ const registerMeta = ({ schemaData }) => {
   }, {});
   const options = Object.keys(nodeProperties)
     .filter(key => nodeProperties[key] === 'string')
-    .map(e => ({ value: e, label: e }));
+    .map(e => ({ value: e, label: e }))
+    .sort((a, b) => a.value.localeCompare(b.value));
 
   return {
     nodeSelectionMode: {
@@ -53,7 +54,11 @@ const registerMeta = ({ schemaData }) => {
       'x-component': 'Select',
       enum: options,
       default: 'id',
+      'x-component-props': {
+        showSearch: true,
+      },
     },
+    ...getNodeFormatOption(options),
     ...metas,
   };
 };

--- a/packages/gi-assets-basic/src/components/PathAnalysis/Component.tsx
+++ b/packages/gi-assets-basic/src/components/PathAnalysis/Component.tsx
@@ -1,6 +1,7 @@
 import { CaretRightOutlined } from '@ant-design/icons';
 import { findShortestPath } from '@antv/algorithm';
 import { NodeSelectionWrap } from '@antv/gi-common-components';
+import type { NodeFormatProps } from '@antv/gi-common-components';
 import { useContext } from '@antv/gi-sdk';
 import { Button, Col, Collapse, Empty, Form, InputNumber, Row, Space, Switch, Timeline, message } from 'antd';
 import { enableMapSet } from 'immer';
@@ -15,7 +16,7 @@ import { getPathByWeight } from './utils';
 
 const { Panel } = Collapse;
 
-export interface IPathAnalysisProps {
+export interface IPathAnalysisProps extends NodeFormatProps {
   hasDirection: boolean;
   hasMaxDeep: boolean;
   nodeSelectionMode: string[];
@@ -31,7 +32,15 @@ export interface IPathAnalysisProps {
 enableMapSet();
 
 const PathAnalysis: React.FC<IPathAnalysisProps> = props => {
-  const { nodeSelectionMode, pathNodeLabel, controlledValues, onOpen = () => {}, hasMaxDeep, hasDirection } = props;
+  const {
+    nodeSelectionMode,
+    pathNodeLabel,
+    controlledValues,
+    onOpen = () => {},
+    hasMaxDeep,
+    hasDirection,
+    labelFormat,
+  } = props;
   const { data: graphData, graph, sourceDataMap, updateHistory } = useContext();
 
   const [state, updateState] = useImmer<IState>({
@@ -336,6 +345,7 @@ const PathAnalysis: React.FC<IPathAnalysisProps> = props => {
             form={form}
             items={items}
             data={graphData.nodes}
+            labelFormat={labelFormat}
             nodeLabel={pathNodeLabel}
             nodeSelectionMode={nodeSelectionMode}
           />

--- a/packages/gi-assets-basic/src/components/PathAnalysis/index.less
+++ b/packages/gi-assets-basic/src/components/PathAnalysis/index.less
@@ -3,7 +3,6 @@
   .gi-path-analysis-container {
     padding: 12px 12px 8px 12px;
     border-radius: 4px;
-    background: #fff;
     margin: 8px 0px;
     position: relative;
   }
@@ -29,8 +28,12 @@
 .gi-collapse-container {
   margin: 1px !important;
   padding: 4px 4px !important;
-  background: var(--background-color);
+  background: var(--background-color, #fff);
   border-radius: 4px !important;
-  box-shadow: -1px -1px 4px 0 hsla(0, 0%, 87.5%, 0.5), -2px 2px 4px 0 hsla(0, 0%, 95.7%, 0.5),
-    2px 3px 8px 2px hsla(0, 0%, 59.2%, 0.05);
+  box-shadow: var(
+    --box-shadow-base,
+    0 3px 6px -4px rgba(0, 0, 0, 0.48),
+    0 6px 16px 0 rgba(0, 0, 0, 0.32),
+    0 9px 28px 8px rgba(0, 0, 0, 0.2)
+  ) !important;
 }

--- a/packages/gi-assets-basic/src/components/PathAnalysis/registerMeta.ts
+++ b/packages/gi-assets-basic/src/components/PathAnalysis/registerMeta.ts
@@ -1,4 +1,4 @@
-import { NodeSelectionMode } from '@antv/gi-common-components/lib/NodeSelectionWrap';
+import { NodeSelectionMode, getNodeFormatOption } from '@antv/gi-common-components';
 import { extra } from '@antv/gi-sdk';
 import $i18n from '../../i18n';
 import info from './info';
@@ -30,7 +30,8 @@ const registerMeta = ({ schemaData }) => {
   }, {});
   const options = Object.keys(nodeProperties)
     .filter(key => nodeProperties[key] === 'string')
-    .map(e => ({ value: e, label: e }));
+    .map(e => ({ value: e, label: e }))
+    .sort((a, b) => a.value.localeCompare(b.value));
 
   return {
     nodeSelectionMode: {
@@ -51,7 +52,11 @@ const registerMeta = ({ schemaData }) => {
       'x-component': 'Select',
       enum: options,
       default: 'id',
+      'x-component-props': {
+        showSearch: true,
+      },
     },
+    ...getNodeFormatOption(options),
     hasDirection: {
       title: $i18n.get({ id: 'basic.components.PathAnalysis.registerMeta.IsThereAnyDirection', dm: '是否有向' }),
       type: 'boolean',

--- a/packages/gi-common-components/src/NodeSelectionWrap/index.less
+++ b/packages/gi-common-components/src/NodeSelectionWrap/index.less
@@ -1,15 +1,20 @@
-.nodeSelectionFromItem {
+.nodeSelectionForm {
+  position: relative;
   display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 10px;
+  flex-direction: column;
+  gap: 24px;
+  margin-bottom: 24px;
 
-  .main {
-    flex: 1;
-  }
-  .operation {
-    width: 20px;
+  .nodeSelectionFormItem {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 10px;
+
+    .main {
+      width: calc(100% - 25px);
+    }
   }
 }
 

--- a/packages/gi-common-components/src/NodeSelectionWrap/index.tsx
+++ b/packages/gi-common-components/src/NodeSelectionWrap/index.tsx
@@ -5,18 +5,87 @@
 import { FormOutlined } from '@ant-design/icons';
 import { Graph } from '@antv/g6';
 import type { FormInstance } from 'antd';
-import { Button, Form, Select, Tooltip } from 'antd';
+import { Button, Form, Select, Tooltip, Typography } from 'antd';
 import React, { memo, useMemo, useState } from 'react';
 import { Icon } from '../Icon';
 import $i18n from '../i18n';
 import './index.less';
+
+const { Text } = Typography;
 
 export enum NodeSelectionMode {
   List = 'List', // 从列表中选择节点
   Canvas = 'Canvas', // 从画布中点选节点
 }
 
-interface NodeSelectionProps {
+export interface NodeFormatProps {
+  labelFormat?: {
+    enable: boolean;
+    mainLabel?: string;
+    subLabel?: string;
+  };
+}
+
+/** 标签格式化 */
+export const getNodeFormatOption = (options: any[]) => ({
+  labelFormat: {
+    title: '标签格式化',
+    type: 'object',
+    properties: {
+      enable: {
+        title: '标签格式化',
+        type: 'boolean',
+        'x-decorator': 'FormItem',
+        'x-component': 'Switch',
+        'x-reactions': [
+          {
+            target: 'labelFormat.mainLabel',
+            fulfill: {
+              state: {
+                visible: '{{$self.value}}',
+              },
+            },
+          },
+          {
+            target: 'labelFormat.subLabel',
+            fulfill: {
+              state: {
+                visible: '{{$self.value}}',
+              },
+            },
+          },
+        ],
+        default: false,
+      },
+      mainLabel: {
+        title: '主标签',
+        type: 'string',
+        'x-decorator': 'FormItem',
+        'x-component': 'Select',
+        enum: options,
+        'x-component-props': {
+          mode: 'tags',
+          allowClear: true,
+          showSearch: true,
+        },
+      },
+      subLabel: {
+        title: '副标签',
+        type: 'string',
+        'x-decorator': 'FormItem',
+        'x-component': 'Select',
+        enum: options,
+        'x-component-props': {
+          mode: 'tags',
+          allowClear: true,
+          showSearch: true,
+        },
+      },
+    },
+  },
+});
+
+interface NodeSelectionProps extends NodeFormatProps {
   graph: Graph;
   form: FormInstance<any>;
   data: Record<string, any>[];
@@ -36,6 +105,7 @@ interface NodeSelectionFormItemProps extends NodeSelectionProps {
   key: string;
   name: string;
   label: string;
+  showDot?: boolean;
   selecting: string;
   setSelecting: React.Dispatch<React.SetStateAction<string>>;
 }
@@ -43,7 +113,21 @@ interface NodeSelectionFormItemProps extends NodeSelectionProps {
 let nodeClickListener = e => {};
 
 const NodeSelectionFormItem: React.FC<NodeSelectionFormItemProps> = memo(props => {
-  const { graph, nodeSelectionMode, nodeLabel, key, name, label, form, data, setSelecting, selecting, color } = props;
+  const {
+    graph,
+    nodeSelectionMode,
+    nodeLabel,
+    key,
+    name,
+    label,
+    form,
+    data,
+    setSelecting,
+    selecting,
+    color,
+    showDot,
+    labelFormat,
+  } = props;
   const isList = nodeSelectionMode.includes(NodeSelectionMode.List);
   const isCanvas = nodeSelectionMode.includes(NodeSelectionMode.Canvas);
 
@@ -72,25 +156,14 @@ const NodeSelectionFormItem: React.FC<NodeSelectionFormItemProps> = memo(props =
   );
 
   return (
-    <div className="nodeSelectionFromItem">
+    <div className="nodeSelectionFormItem">
       <Form.Item
         className="main"
         key={key}
         name={name}
-        label={<Icon type="icon-dot" style={{ fontSize: '12px', color }} />}
+        label={showDot && <Icon type="icon-dot" style={{ fontSize: '12px', color }} />}
         colon={false}
-        rules={[
-          {
-            // required: true,
-            message: $i18n.get(
-              {
-                id: 'common-components.src.NodeSelectionWrap.PleaseFillInLabelNodelabel',
-                dm: `请填写${label}${nodeLabel}`,
-              },
-              { label: label, nodeLabel: nodeLabel },
-            ),
-          },
-        ]}
+        style={{ marginBottom: 0 }}
       >
         <Select
           showSearch
@@ -98,14 +171,34 @@ const NodeSelectionFormItem: React.FC<NodeSelectionFormItemProps> = memo(props =
           onChange={() => {
             setSelecting('');
           }}
+          options={data.map(node => {
+            const value = node[nodeLabel];
+
+            const getLabel = () => {
+              const getByKey = (key: string) => node[key] ?? node.data[key];
+
+              if (!labelFormat?.enable) return <Text>{value}</Text>;
+              const { mainLabel, subLabel } = labelFormat;
+              const mainLabelText: string = mainLabel && getByKey(mainLabel[0]);
+              const subLabelText: string = subLabel && getByKey(subLabel[0]);
+
+              if (!mainLabelText && !subLabelText) return <Text>{value}</Text>;
+              if (!mainLabelText) return <Text type="secondary">{subLabelText}</Text>;
+              if (!subLabelText) return <Text>{mainLabelText}</Text>;
+              return (
+                <>
+                  <Text>{mainLabelText}</Text>
+                  <Text type="secondary">({subLabelText})</Text>
+                </>
+              );
+            };
+
+            const label = getLabel();
+
+            return { label, value };
+          })}
           {...selectProps}
-        >
-          {data.map(node => (
-            <Select.Option key={node.id} value={node.id}>
-              {node[nodeLabel]}
-            </Select.Option>
-          ))}
-        </Select>
+        />
       </Form.Item>
       {isCanvas && (
         <Tooltip
@@ -129,18 +222,17 @@ const NodeSelectionFormItem: React.FC<NodeSelectionFormItemProps> = memo(props =
 });
 
 const NodeSelectionWrap: React.FC<NodeSelectionWrapProps> = memo(props => {
-  const { graph, nodeSelectionMode, nodeLabel, items, form, data } = props;
+  const { graph, nodeSelectionMode, nodeLabel, items, form, data, labelFormat } = props;
   const [selecting, setSelecting] = useState('');
   const colors = ['#1650FF', '#FFC53D'];
   const handleSwap = async () => {
     const values = await form.getFieldsValue();
-    console.log('values', values);
     const { source, target } = values;
     form.setFieldsValue({ source: target, target: source });
   };
 
   return (
-    <div style={{ position: 'relative' }}>
+    <div className="nodeSelectionForm">
       {items.map((item, index) => (
         <NodeSelectionFormItem
           color={colors[index]}
@@ -151,39 +243,43 @@ const NodeSelectionWrap: React.FC<NodeSelectionWrapProps> = memo(props => {
           label={item.label}
           data={data}
           nodeLabel={nodeLabel}
+          labelFormat={labelFormat}
           nodeSelectionMode={nodeSelectionMode}
           selecting={selecting}
           setSelecting={setSelecting}
+          showDot={items.length > 1}
         />
       ))}
-      <div
-        className="gi-path-analysis-line"
-        style={{
-          position: 'absolute',
-          top: '22px',
-          left: '-6px',
-          height: '44px',
-          justifyContent: 'center',
-          alignItems: 'center',
-          display: 'flex',
-        }}
-      >
+      {items.length > 1 && (
         <div
+          className="gi-path-analysis-line"
           style={{
-            height: '38px',
-            width: '1px',
-            background: '#DDDDDF',
             position: 'absolute',
+            top: '22px',
+            left: '-6px',
+            height: '44px',
+            justifyContent: 'center',
+            alignItems: 'center',
+            display: 'flex',
           }}
-        ></div>
-        <Button
-          icon={<Icon type="icon-swap" />}
-          size="small"
-          type="text"
-          onClick={handleSwap}
-          style={{ background: '#fff' }}
-        />
-      </div>
+        >
+          <div
+            style={{
+              height: '38px',
+              width: '1px',
+              background: '#DDDDDF',
+              position: 'absolute',
+            }}
+          ></div>
+          <Button
+            icon={<Icon type="icon-swap" />}
+            size="small"
+            type="text"
+            onClick={handleSwap}
+            style={{ background: 'var(--background-color, #fff)' }}
+          />
+        </div>
+      )}
     </div>
   );
 });

--- a/packages/gi-common-components/src/index.ts
+++ b/packages/gi-common-components/src/index.ts
@@ -17,4 +17,5 @@ export { Icon, icons, registerIconFonts } from './Icon/index';
 export { default as RadiusTabs } from './RadiusTabs';
 export { default as SchemaField } from './SchemaField';
 export { default as Utils } from './Utils';
-export { default as NodeSelectionWrap } from './NodeSelectionWrap';
+export { default as NodeSelectionWrap, NodeSelectionMode, getNodeFormatOption } from './NodeSelectionWrap';
+export type { NodeFormatProps } from './NodeSelectionWrap';


### PR DESCRIPTION
节点选择新增`标签格式化`选项

<img width="293" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/01786241-69f8-4ebd-a04d-4b66b7d70d91">

主要针对`路径分析`和`节点相似度`组件

默认情况下，`标签映射` 同时设置了节点选择器的 `label` 和 `value`

启用该选项后，可以对 `label` 进行定义，支持同时设置`主标签`和`副标签`

<img width="365" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/ca4b7f47-70d1-476b-a1f2-48ef7ada4401">
