### PR TITLE
fix(gi-site): 修复模版使用SegmentedLayout布局时侧边栏默认填充组件

### DIFF
--- a/packages/gi-site/src/services/initial.data/getConfigByEngineId.ts
+++ b/packages/gi-site/src/services/initial.data/getConfigByEngineId.ts
@@ -107,36 +107,40 @@ const getConfigByEngineId = (engineId, template) => {
   const addComponentId = addComponent.map(item => item.id);
   const componentConfig = [...components, ...addComponent];
   //@TODO: 之后增加container，统一处理这段逻辑
-  componentConfig.forEach(item => {
-    if (item.id === 'GrailLayout') {
-      item.props.containers = [
-        {
-          id: 'GI_CONTAINER_RIGHT',
-          GI_CONTAINER: ['FilterPanel', ...addComponentId],
-        },
-      ];
-    }
-    if (item.id === 'SegmentedLayout') {
-      item.props.containers = [
-        {
-          id: 'GI_CONTAINER_SIDE',
-          GI_CONTAINER: [...addComponentId, 'FilterPanel'],
-        },
-      ];
-    }
-    if (item.id === 'UadLayout') {
-      item.props.containers = [
-        {
-          id: 'GI_CONTAINER_TOP',
-          GI_CONTAINER: isCypher ? ['CypherQuery'] : ['GremlinQuery'],
-        },
-        {
-          id: 'GI_CONTAINER_SIDE',
-          GI_CONTAINER: ['JSONMode'],
-        },
-      ];
-    }
-  });
+
+  if(engineId !== 'AKG'){
+    componentConfig.forEach(item => {
+      if (item.id === 'GrailLayout') {
+        item.props.containers = [
+          {
+            id: 'GI_CONTAINER_RIGHT',
+            GI_CONTAINER: ['FilterPanel', ...addComponentId],
+          },
+        ];
+      }
+      if (item.id === 'SegmentedLayout') {
+        item.props.containers = [
+          {
+            id: 'GI_CONTAINER_SIDE',
+            GI_CONTAINER: [...addComponentId, 'FilterPanel'],
+          },
+        ];
+      }
+      if (item.id === 'UadLayout') {
+        item.props.containers = [
+          {
+            id: 'GI_CONTAINER_TOP',
+            GI_CONTAINER: isCypher ? ['CypherQuery'] : ['GremlinQuery'],
+          },
+          {
+            id: 'GI_CONTAINER_SIDE',
+            GI_CONTAINER: ['JSONMode'],
+          },
+        ];
+      }
+    });
+  }
+
 
   const config = {
     nodes,


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->


🐛 Bugfix

- 修复模版使用SegmentedLayout布局时侧边栏默认填充组件



### 📝 Description
问题：创建模版时，如使用了 SegmentedLayout  布局，侧边栏默认填充组件
![image](https://github.com/antvis/G6VP/assets/103234654/bafa6cd9-26c1-4289-8873-8a56fcd835d5)


### 🖼️ Screenshot

**before**
![image](https://github.com/antvis/G6VP/assets/103234654/f133a3a3-57f4-4544-b6c7-41eed4f5f5b9)

**after**
![image](https://github.com/antvis/G6VP/assets/103234654/01b59d61-5de3-411d-813e-5faa3c46c8b1)



<!-- close #0 -->
