### PR TITLE
chore: update icons

### DIFF
--- a/packages/gi-common-components/src/Icon/index.tsx
+++ b/packages/gi-common-components/src/Icon/index.tsx
@@ -36,7 +36,7 @@ export { glyphs, icons };
 
 // --- 注册 antd iconfont ---
 const registeredIds = new Set<string>();
-const builtInIconFontId = 'font_3381398_29c1c449r6f';
+const builtInIconFontId = 'font_3381398_i824ocozt7';
 const getIconfontScriptUrl = (id: string) => `//at.alicdn.com/t/a/${id}.js`;
 
 async function loadUnicodeFonts(ids: string[]) {


### PR DESCRIPTION
图标库里有的图标颜色被写死了，导致无法通过 css 设置颜色，如图
<img width="745" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/6c0b3d6f-58a5-4687-8c03-848fbd600f28">

因此修正并替换了图标

<img width="469" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/0cbbe05b-4d25-4ef1-97fa-7718997de059">
