### PR TITLE
fix(GISDK): canvas loading when fetching schema

### DIFF
--- a/packages/gi-sdk/src/Initializer.tsx
+++ b/packages/gi-sdk/src/Initializer.tsx
@@ -30,6 +30,10 @@ const Initializer: React.FunctionComponent<IProps> = props => {
       service: () => Promise.resolve(null),
     };
 
+    updateContext(draft => {
+      draft.isLoading = true;
+    });
+
     Promise.all([schemaService(), initialService()]).then(([schema, data = { nodes: [], edges: [] }]) => {
       updateContext(draft => {
         const { nodes, edges } = data;
@@ -38,6 +42,7 @@ const Initializer: React.FunctionComponent<IProps> = props => {
           // 更新schemaData
           draft.schemaData = schema as any;
         }
+
 
         const position = isPosition(nodes);
         const style = isStyles(nodes);
@@ -69,6 +74,7 @@ const Initializer: React.FunctionComponent<IProps> = props => {
         }
         draft.initialized = true;
         draft.layoutCache = false;
+        draft.isLoading = false;
       });
     });
   }, [largeGraphLimit]);


### PR DESCRIPTION
### 👀 PR includes


🐛 Bugfix

- [x] schema加载由异步改为同步

### 📝 Description
原来schema 加载是同步的，会导致首次画布加载好时schema没加载到，边的中文映射显示异常
### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ![image](https://github.com/antvis/G6VP/assets/103234654/d3c5aa2e-4faf-498b-a49f-366beaf35ff9) | ![image](https://github.com/antvis/G6VP/assets/103234654/2d62ec3b-6259-4bd6-b0d1-453a41b4df24) |
