### PR TITLE
fix: fix issue that cannot import pattern

### DIFF
--- a/packages/gi-assets-algorithm/package.json
+++ b/packages/gi-assets-algorithm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/gi-assets-algorithm",
-  "version": "2.3.16",
+  "version": "2.3.17",
   "description": "G6VP 图分析算法资产库",
   "repository": {
     "type": "git",

--- a/packages/gi-assets-algorithm/src/PatternMatch/Component.tsx
+++ b/packages/gi-assets-algorithm/src/PatternMatch/Component.tsx
@@ -8,7 +8,7 @@ import { common, useContext } from '@antv/gi-sdk';
 import { GraphinData } from '@antv/graphin';
 import { useMemoizedFn } from 'ahooks';
 import { Button, Col, Dropdown, Menu, Modal, Row, Tabs, Tooltip, message } from 'antd';
-import { cloneDeep, set } from 'lodash';
+import { cloneDeep } from 'lodash';
 import React, { memo, useEffect, useMemo, useRef, useState } from 'react';
 import Util from '../utils';
 import { TypeInfo } from './editDrawer';


### PR DESCRIPTION
> 之前的模式匹配导出模式数据有问题，导入数据也没做处理，因此无法导入导出模式

修复之后，导出的数据格式：

```json
{
  "nodes": [
    {
      "id": "Tom",
      "nodeType": "user",
      "data": { "id": "Tom", "nodeType": "user" }
    },
    {
      "id": "Gina",
      "nodeType": "user",
      "data": { "id": "Gina", "nodeType": "user" }
    }
  ],
  "edges": [
    {
      "id": "Tom-Gina-4",
      "edgeType": "Friends_With",
      "label": "Friends_With-0",
      "source": "Tom",
      "target": "Gina"
    }
  ]
}
```

导入模式后进行匹配：

<img width="939" alt="image" src="https://github.com/antvis/G6VP/assets/25787943/ccfc1113-36e6-409c-b208-a201b44ae8e3">

