### PR TITLE
fix(typo): Change target attribute from _black to _blank

### DIFF
--- a/packages/gi-assets-advance/src/components/TableMode/Component.tsx
+++ b/packages/gi-assets-advance/src/components/TableMode/Component.tsx
@@ -318,7 +318,7 @@ const TableMode: React.FC<IProps> = props => {
     }
     const targetOrigin = window.location.origin + targetWindowPath;
 
-    const targetWindow = window.open(targetOrigin, '_black');
+    const targetWindow = window.open(targetOrigin, '_blank');
     targetWindowRef.current = targetWindow;
     const handleMessage = e => {
       if (e.data.type === 'GI_TABLEMODE_READY' && e.data.payload.isReady) {

--- a/packages/gi-site/src/pages/Analysis/MetaPanel/DataPanel/DataService.tsx
+++ b/packages/gi-site/src/pages/Analysis/MetaPanel/DataPanel/DataService.tsx
@@ -45,7 +45,7 @@ const DataService: React.FunctionComponent<DataServiceProps> = props => {
                 dm: '用户可在线自定义,点击查看',
               })}
 
-              <a href="https://www.yuque.com/antv/gi/iwiv6g" target="_black">
+              <a href="https://www.yuque.com/antv/gi/iwiv6g" target="_blank">
                 {$i18n.get({ id: 'gi-site.MetaPanel.DataPanel.DataService.Document', dm: '文档' })}
               </a>
             </>


### PR DESCRIPTION
### 👀 PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

✨ Feature

- [ ] New feature

🎨 Enhance

- [ ] Code style optimization
- [ ] Refactoring
- [ ] Change the UI
- [ ] Improve the performance
- [ ] Type optimization

🐛 Bugfix

- [x] Solve the issue and close #0 (no existing issue found)

🔧 Chore

- [ ] Test case
- [ ] Docs / demos update
- [ ] CI / workflow
- [ ] Release version
- [ ] Other (<!-- what? -->)

### 📝 Description
This commit addresses the issue where page navigation incorrectly overwrote the content of previously opened tabs. By changing the target attribute of the a-tag from _black to _blank, new pages will now open in a new tab, preventing the overwriting of existing tabs.

### 🖼️ Screenshot

| Before | After |
| ------ | ----- |
| ❌     | ✅    |

### 🔗 Related issue link

<!-- close #0 -->

### 🔍 Self-Check before the merge

- [ ] Add or update relevant docs.
- [ ] Add or update relevant demos.
- [ ] Add or update test case.
- [ ] Add or update relevant TypeScript definitions.
